### PR TITLE
Added logic for deleting and emailing newsletters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 
 **/node_modules/
 **/dist/
+package-lock.json
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/tucklets/app/containers/admin/NewsletterStatusContainer.java
+++ b/src/main/java/com/tucklets/app/containers/admin/NewsletterStatusContainer.java
@@ -1,0 +1,35 @@
+package com.tucklets.app.containers.admin;
+
+public class NewsletterStatusContainer {
+
+    public enum NewsletterStatus {
+        SUCCESS("Success"), ERROR("Error");
+
+        String status;
+
+        NewsletterStatus(String status) {
+            this.status = status;
+        }
+    }
+
+    private NewsletterStatus newsletterStatus;
+    private String newsletterName;
+    private String msg;
+
+    public NewsletterStatusContainer(NewsletterStatus newsletterStatus, String newsletterName, String msg) {
+        this.newsletterStatus = newsletterStatus;
+        this.newsletterName = newsletterName;
+        this.msg = msg;
+    }
+
+    public NewsletterStatusContainer(NewsletterStatus newsletterStatus, String newsletterName) {
+        this.newsletterStatus = newsletterStatus;
+        this.newsletterName = newsletterName;
+        this.msg = "";
+    }
+
+    public static NewsletterStatusContainer createErrorNewsletterStatusContainer(String errorMsg) {
+        return new NewsletterStatusContainer(NewsletterStatus.ERROR, "", errorMsg);
+    }
+
+}

--- a/src/main/java/com/tucklets/app/controllers/admin/NewsletterController.java
+++ b/src/main/java/com/tucklets/app/controllers/admin/NewsletterController.java
@@ -1,26 +1,40 @@
 package com.tucklets.app.controllers.admin;
 
+import com.google.gson.Gson;
 import com.tucklets.app.containers.NewslettersContainer;
+import com.tucklets.app.containers.admin.NewsletterStatusContainer;
+import com.tucklets.app.entities.Sponsor;
 import com.tucklets.app.services.NewsletterService;
+import com.tucklets.app.services.SponsorService;
 import com.tucklets.app.utils.ContainerUtils;
 import com.tucklets.app.utils.NewsletterUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.mail.MessagingException;
 import java.io.IOException;
+import java.util.List;
 
 @Controller
 @RequestMapping(value = "/admin/newsletters")
 public class NewsletterController {
 
+    private static final Gson GSON = new Gson();
+
     @Autowired
     NewsletterService newslettersService;
+
+    @Autowired
+    SponsorService sponsorService;
 
     @GetMapping("/")
     public String viewNewsletters(Model model) {
@@ -37,8 +51,23 @@ public class NewsletterController {
         return "redirect:/admin/newsletters/";
     }
 
+    @DeleteMapping("/remove-newsletter")
+    public String removeNewsletter(@RequestParam("newsletterId") Long newsletterId) {
+        newslettersService.deleteNewsletter(newsletterId);
+        return "success";
+    }
 
-
+    @PutMapping ("/email-latest")
+    @ResponseBody
+    public String emailLatestNewsletter()
+        throws IOException, MessagingException
+    {
+        // Get all subscribed sponsors.
+        List<Sponsor> subscribedSponsors = sponsorService.fetchAllSubscribedSponsors();
+        NewsletterStatusContainer newsletterStatusContainer =
+            newslettersService.emailLatestNewsLetter(subscribedSponsors);
+        return GSON.toJson(newsletterStatusContainer);
+    }
 
 
 

--- a/src/main/java/com/tucklets/app/db/repositories/NewsletterRepository.java
+++ b/src/main/java/com/tucklets/app/db/repositories/NewsletterRepository.java
@@ -20,7 +20,7 @@ public interface NewsletterRepository extends CrudRepository<Newsletter, Long>, 
     List<Newsletter> fetchAllAvailableNewsletters();
 
     @Query("select n from Newsletter n where n.filename = :filename")
-    Optional<Newsletter> fetchNewsletterByFilename(String filename);
+    Optional<Newsletter> fetchNewsletterByFilename(@Param("filename") String filename);
 
     Optional<Newsletter> findFirstByOrderByUploadDateDesc();
 }

--- a/src/main/java/com/tucklets/app/db/repositories/NewsletterRepository.java
+++ b/src/main/java/com/tucklets/app/db/repositories/NewsletterRepository.java
@@ -1,6 +1,5 @@
 package com.tucklets.app.db.repositories;
 
-import com.tucklets.app.entities.ChildAdditionalDetail;
 import com.tucklets.app.entities.Newsletter;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,9 +13,14 @@ import java.util.Optional;
 @Repository
 public interface NewsletterRepository extends CrudRepository<Newsletter, Long>, JpaRepository<Newsletter, Long>{
 
-    @Query("select n from Newsletter n where n.newsletterId = :newsletterId and n.archiveDate is null")
-    Optional<ChildAdditionalDetail> fetchNewslettersByNewsletterId(@Param("newsletterId") Long newsletterId);
+    @Query("select n from Newsletter n where n.newsletterId = :newsletterId")
+    Optional<Newsletter> fetchNewslettersByNewsletterId(@Param("newsletterId") Long newsletterId);
 
-    @Query("select n from Newsletter n where n.archiveDate is null")
-    List<Newsletter> fetchAllAvailableeNewsletters();
+    @Query("select n from Newsletter n order by n.uploadDate desc")
+    List<Newsletter> fetchAllAvailableNewsletters();
+
+    @Query("select n from Newsletter n where n.filename = :filename")
+    Optional<Newsletter> fetchNewsletterByFilename(String filename);
+
+    Optional<Newsletter> findFirstByOrderByUploadDateDesc();
 }

--- a/src/main/java/com/tucklets/app/db/repositories/SponsorRepository.java
+++ b/src/main/java/com/tucklets/app/db/repositories/SponsorRepository.java
@@ -1,6 +1,5 @@
 package com.tucklets.app.db.repositories;
 
-import com.tucklets.app.entities.Child;
 import com.tucklets.app.entities.Sponsor;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -20,4 +19,7 @@ public interface SponsorRepository extends CrudRepository<Sponsor, Long>, JpaRep
 
     @Query("select s from Sponsor s where s.sponsorId = :sponsorId")
     Optional<Sponsor> fetchSponsorById(@Param("sponsorId") Long sponsorId);
+
+    @Query("select s from Sponsor s where s.subscribed is true and s.deletionDate is null")
+    List<Sponsor> fetchSubscribedSponsors();
 }

--- a/src/main/java/com/tucklets/app/entities/Newsletter.java
+++ b/src/main/java/com/tucklets/app/entities/Newsletter.java
@@ -23,12 +23,8 @@ public class Newsletter {
     private String filename;
 
     @Column(name = "upload_date")
-    @Temporal(TemporalType.DATE)
+    @Temporal(TemporalType.TIMESTAMP)
     private Date uploadDate;
-
-    @Column(name = "archive_date")
-    @Temporal(TemporalType.DATE)
-    private Date archiveDate;
 
     private String newsletterLocation;
 
@@ -51,10 +47,6 @@ public class Newsletter {
         return uploadDate;
     }
 
-    public Date getArchiveDate() {
-        return archiveDate;
-    }
-
     public String getNewsletterLocation() {
         return newsletterLocation;
     }
@@ -62,4 +54,5 @@ public class Newsletter {
     public void setNewsletterLocation(String newsletterLocation) {
         this.newsletterLocation = newsletterLocation;
     }
+
 }

--- a/src/main/java/com/tucklets/app/entities/Sponsor.java
+++ b/src/main/java/com/tucklets/app/entities/Sponsor.java
@@ -34,6 +34,9 @@ public class Sponsor {
     @Column(name = "address", nullable = false)
     private String address;
 
+    @Column(name = "subscribed", nullable = false)
+    private boolean subscribed;
+
     @Column(name = "donation_amount", nullable = false)
     private BigDecimal donationAmount;
 
@@ -125,6 +128,14 @@ public class Sponsor {
 
     public void setAddress(String address) {
         this.address = address;
+    }
+
+    public boolean isSubscribed() {
+        return subscribed;
+    }
+
+    public void setSubscribed(boolean subscribed) {
+        this.subscribed = subscribed;
     }
 
     public BigDecimal getDonationAmount() {

--- a/src/main/java/com/tucklets/app/services/EmailService.java
+++ b/src/main/java/com/tucklets/app/services/EmailService.java
@@ -1,8 +1,10 @@
 package com.tucklets.app.services;
 
 import com.tucklets.app.entities.Child;
+import com.tucklets.app.entities.Newsletter;
 import com.tucklets.app.entities.Sponsor;
 import com.tucklets.app.utils.ContainerUtils;
+import com.tucklets.app.utils.S3Utils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -10,6 +12,7 @@ import org.springframework.mail.javamail.MimeMessagePreparator;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
+
 import java.util.List;
 
 @Service
@@ -21,8 +24,11 @@ public class EmailService {
     @Autowired
     TemplateEngine templateEngine;
 
+    @Autowired
+    SimpleS3Service simpleS3Service;
+
     public void sendConfirmationEmail(Sponsor sponsor, List<Child> children) {
-        // from recipent is defined in application.properties
+        // from recipient is defined in application.properties
         MimeMessagePreparator messagePreparator = message -> {
             MimeMessageHelper helper = new MimeMessageHelper(message, true);
             helper.setTo(sponsor.getEmail());
@@ -40,6 +46,38 @@ public class EmailService {
         context.setVariable("sponsor", sponsor);
         context.setVariable("localeContainer", ContainerUtils.createLocaleContainer());
 
-        return templateEngine.process("confirmation-email", context);
+        return templateEngine.process("emails/confirmation-email", context);
+    }
+
+    /**
+     * Sends newsletter email with the newsletter attached.
+     */
+    public void sendNewsletterEmail(List<Sponsor> sponsors, Newsletter newsletter) {
+        String newsletterLink = S3Utils.computeS3Key(newsletter.getFilename(), S3Utils.S3_NEWSLETTERS_BUCKET_BASE_URL);
+
+        for (Sponsor sponsor : sponsors) {
+            MimeMessagePreparator messagePreparator = message -> {
+                MimeMessageHelper helper = new MimeMessageHelper(message, true);
+                helper.setTo(sponsor.getEmail());
+                helper.setSubject("Tucklets - Please check out our new newsletter! ");
+                String emailContent = buildNewsletterEmail(sponsor, newsletterLink);
+                helper.setText(emailContent, true);
+            };
+            javaMailSender.send(messagePreparator);
+        }
+
+    }
+
+    /**
+     * Builds the actual content of the email to send out using the newsletter template.
+     * @param sponsor that the email will be sent to.
+     * @return htmlString used to the email content.
+     */
+    private String buildNewsletterEmail (Sponsor sponsor, String newsletterLink) {
+        Context context = new Context();
+        context.setVariable("sponsor", sponsor);
+        context.setVariable("newsletterLink", newsletterLink);
+
+        return templateEngine.process("emails/newsletter-email", context);
     }
 }

--- a/src/main/java/com/tucklets/app/services/NewsletterService.java
+++ b/src/main/java/com/tucklets/app/services/NewsletterService.java
@@ -1,18 +1,26 @@
 package com.tucklets.app.services;
 
+import com.tucklets.app.containers.admin.NewsletterStatusContainer;
+import com.tucklets.app.containers.admin.NewsletterStatusContainer.NewsletterStatus;
 import com.tucklets.app.db.repositories.NewsletterRepository;
 import com.tucklets.app.entities.Newsletter;
+import com.tucklets.app.entities.Sponsor;
 import com.tucklets.app.utils.S3Utils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.mail.MessagingException;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class NewsletterService {
+
+    @Autowired
+    EmailService emailService;
 
     @Autowired
     NewsletterRepository newsletterRepository;
@@ -29,20 +37,74 @@ public class NewsletterService {
      * Returns all available newsletters.
      */
     public List<Newsletter> fetchAllAvailableNewsletters() {
-        return newsletterRepository.fetchAllAvailableeNewsletters();
+        return newsletterRepository.fetchAllAvailableNewsletters();
     }
 
     /**
      * Uploads the provided file into S3 and stores its meta information in the database.
      */
     public void uploadAndSaveNewsletter(MultipartFile file) throws IOException {
+        // Check if file already exists. If it does, do nothing.
+        String filename = file.getOriginalFilename();
+        Optional<Newsletter> newsletterOptional = newsletterRepository.fetchNewsletterByFilename(filename);
+        if (newsletterOptional.isPresent()) {
+           // Found a newsletter with the same name.
+            return;
+        }
         // Upload file.
         simpleS3Service.uploadFile(
-            file.getOriginalFilename(),
+            filename,
             S3Utils.convertMultiPartToFile(file),
             S3Utils.S3_NEWSLETTERS_BUCKET_NAME);
 
         // Store metadata in db.
         addNewsletter(new Newsletter(file.getOriginalFilename(), new Date()));
+    }
+
+    /**
+     * Hard removal of the given newsletter.
+     */
+    public void deleteNewsletter(long newsletterId) throws IllegalStateException {
+        Optional<Newsletter> newsletterOptional = newsletterRepository.fetchNewslettersByNewsletterId(newsletterId);
+        // If newsletter is valid/exists
+        if (newsletterOptional.isPresent()) {
+            Newsletter newsletter = newsletterOptional.get();
+            String newsletterLocation = newsletter.getFilename();
+            simpleS3Service.deleteFile(newsletterLocation, S3Utils.S3_NEWSLETTERS_BUCKET_NAME);
+            newsletterRepository.delete(newsletter);
+        }
+        else {
+            throw new IllegalStateException(
+                String.format("Newsletter: %d could not be deleted because it does not exist.", newsletterId));
+        }
+    }
+
+    /**
+     * Sends email to all the provided addresses containing the newsletter that should be shared.
+     */
+    public NewsletterStatusContainer emailLatestNewsLetter(List<Sponsor> sponsors)
+        throws IllegalStateException, MessagingException, IOException
+    {
+        Optional<Newsletter> newsletterOpt = newsletterRepository.findFirstByOrderByUploadDateDesc();
+        if (newsletterOpt.isEmpty()) {
+            return NewsletterStatusContainer.createErrorNewsletterStatusContainer("Cannot locate latest newsletter.");
+        }
+        Newsletter newsletter = newsletterOpt.get();
+        emailService.sendNewsletterEmail(sponsors, newsletter);
+        return new NewsletterStatusContainer(NewsletterStatus.SUCCESS, newsletter.getFilename());
+    }
+
+    /**
+     * Sends email to all the provided addresses containing the newsletter that should be shared.
+     */
+    public void emailNewsLetter(long newsletterId, List<Sponsor> sponsors)
+        throws IllegalStateException, MessagingException, IOException
+    {
+        Optional<Newsletter> newsletterOpt = newsletterRepository.fetchNewslettersByNewsletterId(newsletterId);
+        if (newsletterOpt.isEmpty()) {
+            throw new IllegalStateException(String.format("Cannot email out newsletter: %d", newsletterId));
+        }
+        Newsletter newsletter = newsletterOpt.get();
+        emailService.sendNewsletterEmail(sponsors, newsletter);
     }
 }

--- a/src/main/java/com/tucklets/app/services/SimpleS3Service.java
+++ b/src/main/java/com/tucklets/app/services/SimpleS3Service.java
@@ -5,6 +5,7 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.S3Object;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
@@ -42,5 +43,42 @@ public class SimpleS3Service {
             // Log error.
             e.printStackTrace();
         }
+    }
+
+    /**
+     * Delete object from S3.
+     * @param fileName to be deleted (S3 key)
+     * @param bucketName destination in S3 that the file is stored in.
+     */
+    public void deleteFile(String fileName, String bucketName) {
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder
+                .standard()
+                .build();
+
+            s3Client.deleteObject(bucketName, fileName);
+        } catch (SdkClientException e) {
+            // Log error.
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Fetches object from S3.
+     * @param fileName to be retrieved (S3 key)
+     * @param bucketName destination in S3 that the file is stored in.
+     */
+    public S3Object retrieveFile(String fileName, String bucketName) {
+        try {
+            AmazonS3 s3Client = AmazonS3ClientBuilder
+                .standard()
+                .build();
+
+            return s3Client.getObject(bucketName, fileName);
+        } catch (SdkClientException e) {
+            // Log error.
+            e.printStackTrace();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/tucklets/app/services/SponsorService.java
+++ b/src/main/java/com/tucklets/app/services/SponsorService.java
@@ -1,7 +1,6 @@
 package com.tucklets.app.services;
 
 import com.tucklets.app.db.repositories.SponsorRepository;
-import com.tucklets.app.entities.Child;
 import com.tucklets.app.entities.Sponsor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -21,6 +20,13 @@ public class SponsorService {
      */
     public List<Sponsor> fetchAllSponsors() {
         return sponsorRepository.fetchAllSponsors();
+    }
+
+    /**
+     * Fetches all active sponsors who are subscribed to receive notifications.
+     */
+    public List<Sponsor> fetchAllSubscribedSponsors() {
+        return sponsorRepository.fetchSubscribedSponsors();
     }
 
     public Sponsor fetchSponsorById(Long sponsorId) {

--- a/src/main/java/com/tucklets/app/utils/S3Utils.java
+++ b/src/main/java/com/tucklets/app/utils/S3Utils.java
@@ -31,9 +31,9 @@ public class S3Utils {
     }
 
     /**
-     * Computes the S3 key for the given image location.
+     * Computes the S3 key for the given file location.
      */
-    public static String computeS3Key(String imageLocation, String baseUrl) {
-        return baseUrl + imageLocation;
+    public static String computeS3Key(String fileLocation, String baseUrl) {
+        return baseUrl + fileLocation;
     }
 }

--- a/src/main/resources/schema.txt
+++ b/src/main/resources/schema.txt
@@ -42,7 +42,7 @@ CREATE TABLE Sponsor(
    church_name VARCHAR (50),
    email VARCHAR (250),
    address VARCHAR(250),
-   receive_notifications boolean NOT NULL,
+   subscribed boolean NOT NULL,
    donation_amount DECIMAL(12, 2) NOT NULL,
    payment_method SMALLINT NOT NULL,
    creation_date TIMESTAMP NOT NULL,

--- a/src/main/resources/schema.txt
+++ b/src/main/resources/schema.txt
@@ -42,6 +42,7 @@ CREATE TABLE Sponsor(
    church_name VARCHAR (50),
    email VARCHAR (250),
    address VARCHAR(250),
+   receive_notifications boolean NOT NULL,
    donation_amount DECIMAL(12, 2) NOT NULL,
    payment_method SMALLINT NOT NULL,
    creation_date TIMESTAMP NOT NULL,
@@ -59,5 +60,4 @@ CREATE TABLE Newsletter(
    newsletter_id serial PRIMARY KEY;
    filename VARCHAR (250) NOT NULLL;
    upload_date TIMESTAMP NOT NULL,
-   archive_date TIMESTAMP,
 );

--- a/src/main/resources/static/css/admin/dashboard.css
+++ b/src/main/resources/static/css/admin/dashboard.css
@@ -57,7 +57,7 @@
   background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
 }
 
-.delete-child-button {
+.delete-button {
     height: 20px;
     width: 20px;
 }

--- a/src/main/resources/static/css/admin/newsletter.css
+++ b/src/main/resources/static/css/admin/newsletter.css
@@ -1,0 +1,9 @@
+.newsletter.hidden-message {
+    color: #008000;
+    display: none;
+    border: 1px solid #008000;
+    border-radius: 10px;
+    padding: 10px;
+    float: right;
+
+}

--- a/src/main/resources/static/js/admin/children-dashboard.js
+++ b/src/main/resources/static/js/admin/children-dashboard.js
@@ -11,7 +11,6 @@ function closeModal() {
 }
 
 function handleDeleteChild(childId) {
-    console.log(childId);
     let childRow = $('#child-row' + childId);
     $.ajax({
         url: '/admin/children-dashboard/remove-child',

--- a/src/main/resources/static/js/admin/manage-newsletters.js
+++ b/src/main/resources/static/js/admin/manage-newsletters.js
@@ -1,0 +1,35 @@
+function handleDeleteNewsletter(newsletterId) {
+    let newsletterRow = $('#newsletter-row' + newsletterId);
+    $.ajax({
+        url: '/admin/newsletters/remove-newsletter',
+        type: 'DELETE',
+        data: { "newsletterId": newsletterId },
+        success: function(newsletterResponse) {
+            newsletterRow.addClass("deleted-row-styling");
+        },
+        error : function() {
+        // TODO: Error handling.
+            console.log("error");
+        }
+    });
+}
+
+function handleEmailNewsletter() {
+    let newsletterMessage = $('.newsletter.hidden-message');
+    $.ajax({
+        url: '/admin/newsletters/email-latest',
+        type: 'PUT',
+        success: function(newsletterResponse) {
+            newsletterMessage.show();
+            let newsletterStatus = JSON.parse(newsletterResponse);
+            let newsletterName = newsletterStatus.newsletterName;
+            setTimeout(function () {
+                newsletterMessage.hide();
+            }, 8000);
+        },
+        error : function(errorResponse) {
+        // TODO: Error handling.
+            console.log("Error sending newsletter email.");
+        }
+    });
+}

--- a/src/main/resources/templates/admin/children-dashboard.html
+++ b/src/main/resources/templates/admin/children-dashboard.html
@@ -40,7 +40,7 @@
             </thead>
             <tbody>
             <tr th:each="childContainer : ${childrenDetails}" th:id="child-row + ${childContainer.child.childId}">
-                <td><input type="image" class="delete-child-button" src="/images/red-x.jpg" th:onclick="|handleDeleteChild('${childContainer.child.childId}')|" /> </td>
+                <td><input type="image" class="delete-button" src="/images/red-x.jpg" th:onclick="|handleDeleteChild('${childContainer.child.childId}')|" /> </td>
                 <td><img class="icon-image" th:src="${childContainer.childImageLocation}" /></td>
                 <td th:text="*{childContainer.child.childId}"/>
                 <td th:text="*{childContainer.child.firstName}"/>

--- a/src/main/resources/templates/admin/manage-newsletters.html
+++ b/src/main/resources/templates/admin/manage-newsletters.html
@@ -4,7 +4,9 @@
     <div th:replace="common-head :: common-head"></div>
     <link rel="stylesheet" th:href="@{/css/admin/dashboard.css}">
     <link rel="stylesheet" th:href="@{/css/admin/admin-common.css}">
+    <link rel="stylesheet" th:href="@{/css/admin/newsletter.css}">
     <script type="text/javascript" th:src="@{/js/admin/upload-data.js}"></script>
+    <script type="text/javascript" th:src="@{/js/admin/manage-newsletters.js}"></script>
 </head>
 
 <body>
@@ -21,23 +23,24 @@
 
     <div class="children-table">
         <h4>Newsletters</h4>
+        <input type="button" class="btn btn-primary upload-button" value="Email latest newsletter" th:onclick="handleEmailNewsletter()" />
+        <span class="newsletter hidden-message">Email was sent successfully!</span>
         <table class="table table-striped table-bordered children-data-table">
             <thead>
             <tr>
-                <th scope="col">Newsletter Id</th>
+                <th></th>
                 <th scope="col">Filename</th>
                 <th scope="col">Location</th>
                 <th scope="col">Upload Date</th>
-                <th scope="col">Deletion Date</th>
+
             </tr>
             </thead>
             <tbody>
             <tr th:each="newsletter : ${newslettersContainer.newsletters}" th:id="newsletter-row + ${newsletter.newsletterId}">
-                <td th:text="${newsletter.newsletterId}"/>
+                <td><input type="image" class="delete-button" src="/images/red-x.jpg" th:onclick="|handleDeleteNewsletter('${newsletter.newsletterId}')|" /> </td>
                 <td th:text="${newsletter.filename}"/>
                 <td><a target="_blank" th:href="${newsletter.newsletterLocation}" th:text="${newsletter.newsletterLocation}"/></td>
                 <td th:text="${newsletter.uploadDate}"/>
-                <td th:text="${newsletter.archiveDate}"/>
             </tr>
             </tbody>
         </table>
@@ -48,7 +51,7 @@
                     <b>Please upload your newsletter here</b>
                 </p>
                 <div class="upload-area-div">
-                    <span>Please upload a file (.pdf)</span>
+                    <span>Please upload a file (.pdf). Keep in mind that if you upload a newsletter with the same name, the newsletter will not get uploaded.</span>
                     <input class="form-control upload-file-button" type="file" name="file" accept="pdf" onchange="handleUploadFile()">
                 </div>
                 <div>

--- a/src/main/resources/templates/admin/sponsor-dashboard.html
+++ b/src/main/resources/templates/admin/sponsor-dashboard.html
@@ -36,12 +36,13 @@
         <th scope="col">Creation Date</th>
         <th scope="col">Deletion Date</th>
         <th scope="col">Last Update Date</th>
+        <th scope="col">Is subscribed</th>
         <th scope="col">Action</th>
       </tr>
       </thead>
       <tbody>
       <tr th:each="sponsor : ${sponsors}" th:id="sponsor-row + ${sponsor.sponsorId}">
-        <td><input type="image" class="delete-child-button" src="/images/red-x.jpg" th:onclick="|handleDeleteSponsor('${sponsor.sponsorId}')|" /> </td>
+        <td><input type="image" class="delete-button" src="/images/red-x.jpg" th:onclick="|handleDeleteSponsor('${sponsor.sponsorId}')|" /> </td>
         <td th:text="${sponsor.sponsorId}"/>
         <td th:text="${sponsor.firstName}"/>
         <td th:text="${sponsor.lastName}"/>
@@ -53,6 +54,8 @@
         <td th:text="${sponsor.creationDate}"/>
         <td th:text="${sponsor.deletionDate}"/>
         <td th:text="${sponsor.lastUpdateDate}"/>
+        <td th:text="${sponsor.subscribed}"/>
+
         <td>
           <input type="button" class="btn btn-primary" value="Edit" th:onclick="|handleEditSponsorClick('${sponsor.sponsorId}')|" />
         </td>

--- a/src/main/resources/templates/emails/confirmation-email.html
+++ b/src/main/resources/templates/emails/confirmation-email.html
@@ -19,7 +19,7 @@
 <div class="container" style="">
   <p>
     <p class="" th:text="|Dear ${sponsor.firstName} ${sponsor.lastName},|"></p>
-    <p class="">Thank you for supporting Tuckets, a 501(c)(3) public benefit charitable corperation. </p>
+    <p class="">Thank you for supporting Tuckets, a 501(c)(3) public benefit charitable corporation. </p>
     <p class="">Here is a receipt of your donation: </p>
     <p class="" th:text="| Amount: $ ${sponsor.donationAmount} |"></p>
   </p>
@@ -30,7 +30,7 @@
   <div>
     <p> Thank you again for your donation. Please keep this for your records.</p>
     <p> Sincerely, </p>
-    <p> Tuckets Foundation</p>
+    <p> Tucklets Foundation</p>
     <a href="https://tucklets.org" class="btn btn-primary">Go to Tucklets.org</a>
   </div>
 </div>

--- a/src/main/resources/templates/emails/newsletter-email.html
+++ b/src/main/resources/templates/emails/newsletter-email.html
@@ -1,0 +1,29 @@
+<!DOCTYPE HTML>
+<html lang="en" xmlns:th="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+    <link rel="stylesheet" href="../static/css/common.css">
+</head>
+<body>
+<div class="banner">
+    <div>
+        <nav class="navbar navbar-light navbar-custom">
+            <a class="navbar-brand" href="#">
+                <img class="d-inline-block align-top tucklets-logo" alt="" src="../../static/images/tucklets-icon.PNG"/>
+            </a>
+        </nav>
+    </div>
+</div>
+<div class="container" style="">
+    <p>
+    <p class="" th:text="|Dear ${sponsor.firstName} ${sponsor.lastName},|"></p>
+    <p class="">Thank you for supporting Tuckets, a 501(c)(3) public benefit charitable corporation. </p>
+    <p class="">Here is our latest <a th:href="${newsletterLink}">newsletter!</a> </p>
+    <p> Thank you again for your support!</p>
+    <p> Sincerely, </p>
+    <p> Tucklets Foundation</p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
- Admin workflow now supports deleting newsletters and emailing the latest newsletter.
- Emails are sent to each sponsor individually, so we get a more personal touch.
- Improved logic so if there are duplicate filenames, backend will drop the request and we won't add a duplicate newsletter.
- Created a new email template for the newsletter email; hyperlink will navigate user to newsletter in S3.