### PR TITLE
Sponsor info submission without paypal

### DIFF
--- a/frontend/jsx/Main.jsx
+++ b/frontend/jsx/Main.jsx
@@ -10,6 +10,7 @@ import OurStoryPage from './pages/OurStoryPage';
 import NewslettersPage from './pages/NewslettersPage';
 import SponsorChildPage from './pages/SponsorChildPage';
 import SponsorInfoPage from './pages/SponsorInfoPage';
+import SponsorThankYouPage from './pages/SponsorThankYouPage';
 import DonatePage from './pages/DonatePage';
 import Footer from './common/Footer';
 import i18n from './common/i18n';
@@ -26,7 +27,8 @@ class Main extends Component {
             selectedLocale: 'en-US', 
             selectedChildren: [], 
             // Initialize donation amount for inital render.
-            sponsor: {donationAmount: 0},
+            sponsor: {},
+            donation: {donationAmount: 0, donationDuration: 0}
         };
 
         // Bind handlers
@@ -47,7 +49,7 @@ class Main extends Component {
     /**
      * Handles form submission after user has selected the children he or she wants to sponsor.
      */
-    handleSponsorChildSubmission(childrenSelections) {
+    handleSponsorChildSubmission(childrenSelections, history) {
         let self = this;
         return () => {
             let selectedChildrenIds = []
@@ -67,7 +69,10 @@ class Main extends Component {
                 self.setState({ 
                     selectedChildren: response.data.children, 
                     sponsor: response.data.sponsor,
+                    donation: response.data.donation,
                 });
+                // Manually change route after successful response from backend.
+                history.push("/sponsor-info/");
             })
             .catch(function (error) {
                 console.log(error);
@@ -83,7 +88,7 @@ class Main extends Component {
         let self = this;
         return () => {
             self.setState({ 
-                sponsor: {donationAmount: parseInt(amount)}
+                donation: {donationAmount: parseInt(amount), donationDuration: 0}
             });
         }
 
@@ -99,8 +104,14 @@ class Main extends Component {
                     <Route exact path="/sponsor-info/">
                         <SponsorInfoPage 
                             selectedChildren={this.state.selectedChildren} 
-                            donationAmount={this.state.sponsor.donationAmount} 
-                            i18n={i18n} handleSelectedLocaleChange={this.handleSelectedLocaleChange} 
+                            donationAmount={this.state.donation.donationAmount}
+                            donationDuration={this.state.donation.donationDuration} 
+                            i18n={i18n} 
+                            handleSelectedLocaleChange={this.handleSelectedLocaleChange} 
+                        />
+                    </Route>
+                    <Route exact path="/thank-you/">
+                        <SponsorThankYouPage i18n={i18n} handleSelectedLocaleChange={this.handleSelectedLocaleChange} 
                         />
                     </Route>
                     <Route exact path="/">
@@ -114,7 +125,7 @@ class Main extends Component {
                         <br />
                         <DonatePage i18n={i18n} handleSelectedLocaleChange={this.handleSelectedLocaleChange} handleDonationClick={this.handleDonationClick}  />
                         <br />
-                        <SponsorChildPage i18n={i18n} handleSelectedLocaleChange={this.handleSelectedLocaleChange} handleSponsorChildSubmission={this.handleSponsorChildSubmission}  />
+                        <SponsorChildPage i18n={i18n} handleSelectedLocaleChange={this.handleSelectedLocaleChange} handleSponsorChildSubmission={this.handleSponsorChildSubmission} />
                         <br />
                     </Route>
                     

--- a/frontend/jsx/common/i18n.js
+++ b/frontend/jsx/common/i18n.js
@@ -15,6 +15,8 @@ import sponsorship_en_us from './i18n/sponsorship/en_us.json';
 import sponsorship_zh_tw from './i18n/sponsorship/zh_tw.json';
 import sponsor_info_en_us from './i18n/sponsor-info/en_us.json';
 import sponsor_info_zh_tw from './i18n/sponsor-info/zh_tw.json';
+import sponsor_thank_you_en_us from './i18n/sponsor-thank-you/en_us.json';
+import sponsor_thank_you_zh_tw from './i18n/sponsor-thank-you/zh_tw.json';
 import donate_zh_tw from './i18n/donate/zh_tw.json';
 import donate_en_us from './i18n/donate/en_us.json';
 import footer_zh_tw from './i18n/footer/zh_tw.json';
@@ -39,6 +41,7 @@ i18n
           navigation: navigation_en_us,
           sponsorship: sponsorship_en_us,
           sponsor_info: sponsor_info_en_us,
+          sponsor_thank_you: sponsor_thank_you_en_us,
           donate: donate_en_us,
           footer: footer_en_us
       },
@@ -50,6 +53,7 @@ i18n
           navigation: navigation_zh_tw,
           sponsorship: sponsorship_zh_tw,
           sponsor_info: sponsor_info_zh_tw,
+          sponsor_thank_you: sponsor_thank_you_zh_tw,
           donate: donate_zh_tw,
           footer: footer_zh_tw
       }

--- a/frontend/jsx/common/i18n/sponsor-thank-you/en_us.json
+++ b/frontend/jsx/common/i18n/sponsor-thank-you/en_us.json
@@ -1,0 +1,8 @@
+{
+    "sponsor-thank-you": "Thank You",
+    "title": "Thank You",
+    "subtitle": "Thank you for your generous gift!",
+    "processed_text": "Your donation has been processed. You should receive a confirmation email shortly.",
+    "impact_text": "Your efforts will ignite a hope for orphaned children in Kenya. Together, we are closer to cultivating brighter futures for each one of them.",
+    "home": "Home"
+}

--- a/frontend/jsx/common/i18n/sponsor-thank-you/zh_tw.json
+++ b/frontend/jsx/common/i18n/sponsor-thank-you/zh_tw.json
@@ -1,0 +1,8 @@
+{
+    "sponsor-thank-you": "Thank You",
+    "title": "Thank You",
+    "subtitle": "Thank you for your generous gift!",
+    "processed_text": "Your donation has been processed. You should receive a confirmation email shortly.",
+    "impact_text": "Your efforts will ignite a hope for orphaned children in Kenya. Together, we are closer to cultivating brighter futures for each one of them.",
+    "home": "Home"
+}

--- a/frontend/jsx/pages/SponsorChildPage.jsx
+++ b/frontend/jsx/pages/SponsorChildPage.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import axios from 'axios';
 import { PropTypes } from 'prop-types';
-import { Link } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 
 import '../../static/scss/sponsor-a-child.scss';
 
@@ -103,7 +103,7 @@ class SponsorChildPage extends Component {
                     <div className="container children-div">
                         { this.renderChildrenComponents() }
                     </div>
-                    <Link to="/sponsor-info/" className="btn btn-primary sponsor-now-button" value={this.props.i18n.t("sponsorship:submit")} onClick={this.props.handleSponsorChildSubmission(this.state.childrenSelections)}>{this.props.i18n.t("sponsorship:submit")}</Link>
+                    <button className="btn btn-primary sponsor-now-button" onClick={this.props.handleSponsorChildSubmission(this.state.childrenSelections, this.props.history)}>{this.props.i18n.t("sponsorship:submit")}</button>
 
                 </div>
             </div>
@@ -115,4 +115,4 @@ class SponsorChildPage extends Component {
 
 SponsorChildPage.propTypes = props;
 
-export default SponsorChildPage;
+export default withRouter(SponsorChildPage);

--- a/frontend/jsx/pages/SponsorInfoPage.jsx
+++ b/frontend/jsx/pages/SponsorInfoPage.jsx
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
 import { PropTypes } from 'prop-types';
+import { Link, withRouter } from 'react-router-dom'
+import axios from 'axios';
 
-import '../../static/scss/sponsor-a-child.scss';
+import '../../static/scss/basic.scss';
 import '../../static/scss/sponsor-info.scss';
 
 const props = {
@@ -13,6 +15,8 @@ const props = {
     selectedChildren: PropTypes.array,
     /** The donation amount provided either by the user or by the backend. */
     donationAmount: PropTypes.number.isRequired,
+    /** The donation duration provided by the user. */
+    donationDuration: PropTypes.number
 }
 
 class SponsorInfoPage extends Component {
@@ -20,13 +24,88 @@ class SponsorInfoPage extends Component {
     constructor(props) {
         super(props);
         console.log(props);
-        this.state = { };
+        this.state = {
+            sponsor: {
+                firstName: "",
+                lastName: "",
+                email: "",
+                address: "",
+                churchName: ""
+            },
+            donation: {
+                donationAmount: props.donationAmount,
+                donationDuration: props.donationDuration,
+                // default to 0 for now.
+                paymentMethod: 0
+            },
 
+         };
+
+         console.log(this.state);
+
+        this.donationInfoChangeHandler = this.donationInfoChangeHandler.bind(this);
         this.renderSelectedChildren = this.renderSelectedChildren.bind(this);
+        this.sponsorInfoChangeHandler = this.sponsorInfoChangeHandler.bind(this);
+        this.sponsorInfoSubmitHandler = this.sponsorInfoSubmitHandler.bind(this);
     }
 
     componentDidMount(){ 
         window.scrollTo(0,0);
+    }
+
+    /**
+     * Handler for sponsor info changes.
+     */
+    sponsorInfoChangeHandler(field) {
+        let self = this;
+        return (event) => {
+            let newValue = event.target.value;
+            self.setState(prevState => ({
+                sponsor: {
+                    ...prevState.sponsor,
+                    [field]: newValue
+                },
+            }));
+        }
+    }
+
+    /**
+     * Handler for donation info changes.
+     */
+    donationInfoChangeHandler(field) {
+        let self = this;
+        return (event) => {
+            let newValue = event.target.value;
+            self.setState(prevState => ({
+                donation: {
+                    ...prevState.donation,
+                    [field]: newValue
+                },
+            }));
+        }
+    }
+
+    /**
+     * Handler for the sponsor info submission button.
+     */
+    sponsorInfoSubmitHandler() {
+        let self = this;
+        console.log(this.state);
+        let selectedChildIds = [];
+        this.props.selectedChildren.map((childContainer) => selectedChildIds.push(childContainer.child.childId));
+        axios.post('/sponsor-info/submit/', {
+            sponsor: this.state.sponsor,
+            donation: this.state.donation,
+            children: selectedChildIds
+
+        })
+        .then(function (response) {
+            console.log(response);
+            self.props.history.push("/thank-you/");
+        })
+        .catch(function (error) {
+            console.log(error);
+        });
     }
 
     renderSelectedChildren() {
@@ -69,21 +148,22 @@ class SponsorInfoPage extends Component {
                         <fieldset>
                             <legend><span className="sponsor-info-section-number">1</span><span>{`${this.props.i18n.t("sponsor_info:form_header_personal")}`}</span></legend>
                             <label htmlFor="sponsor-first-name">{`${this.props.i18n.t("sponsor_info:form_first_name")}`}</label>
-                            <input type="text" id="sponsor-first-name" placeholder={this.props.i18n.t("sponsor_info:form_placeholder_first_name")} />
+                            <input type="text" id="sponsor-first-name" placeholder={this.props.i18n.t("sponsor_info:form_placeholder_first_name")} value={this.state.sponsor.firstName} onChange={this.sponsorInfoChangeHandler("firstName")} />
                             <label htmlFor="sponsor-last-name">{`${this.props.i18n.t("sponsor_info:form_last_name")}`}</label>
-                            <input type="text" id="sponsor-last-name" placeholder={this.props.i18n.t("sponsor_info:form_placeholder_last_name")} />
+                            <input type="text" id="sponsor-last-name" placeholder={this.props.i18n.t("sponsor_info:form_placeholder_last_name")} value={this.state.sponsor.lastName} onChange={this.sponsorInfoChangeHandler("lastName")} />
                             <label htmlFor="sponsor-email">{`${this.props.i18n.t("sponsor_info:form_email")}`}</label>
-                            <input type="text" id="sponsor-email" placeholder={this.props.i18n.t("sponsor_info:form_placeholder_email")} />
+                            <input type="text" id="sponsor-email" placeholder={this.props.i18n.t("sponsor_info:form_placeholder_email")} value={this.state.sponsor.email} onChange={this.sponsorInfoChangeHandler("email")} />
                             <label htmlFor="sponsor-address">{`${this.props.i18n.t("sponsor_info:form_address")}`}</label>
-                            <input type="text" id="sponsor-address" placeholder={this.props.i18n.t("sponsor_info:form_placeholder_address")} />
+                            <input type="text" id="sponsor-address" placeholder={this.props.i18n.t("sponsor_info:form_placeholder_address")} value={this.state.sponsor.address} onChange={this.sponsorInfoChangeHandler("address")} />
                             <label htmlFor="sponsor-church-name">{`${this.props.i18n.t("sponsor_info:form_church_name")}`}</label>
-                            <input type="text" id="sponsor-church-name" placeholder={this.props.i18n.t("sponsor_info:form_placeholder_church_name")} />
+                            <input type="text" id="sponsor-church-name" placeholder={this.props.i18n.t("sponsor_info:form_placeholder_church_name")} value={this.state.sponsor.churchName} onChange={this.sponsorInfoChangeHandler("churchName")} />
                         </fieldset>
                         <fieldset>
                             <legend><span className="sponsor-info-section-number">2</span><span>{`${this.props.i18n.t("sponsor_info:form_header_donation_info")}`}</span></legend>
                             <label htmlFor="donation-amount">{`${this.props.i18n.t("sponsor_info:form_amount")}`}</label>
                             <input type="text" id="donation-amount" readOnly value={this.props.donationAmount} />
                         </fieldset>
+                        <div className="btn btn-primary tucklets-button" onClick={this.sponsorInfoSubmitHandler}>{`${this.props.i18n.t("sponsor_info:form_submit")}`}</div>
                     </form>
                 </div>
             </div>
@@ -94,4 +174,4 @@ class SponsorInfoPage extends Component {
 }
 SponsorInfoPage.propTypes = props;
 
-export default SponsorInfoPage;
+export default withRouter(SponsorInfoPage);

--- a/frontend/jsx/pages/SponsorThankYouPage.jsx
+++ b/frontend/jsx/pages/SponsorThankYouPage.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+
+import '../../static/scss/info.scss';
+import '../../static/scss/thank-you.scss';
+
+
+const props = {
+    /** i18n object to help with translations.*/
+    i18n: PropTypes.object.isRequired,
+    /** Handler for updating the selected locale. */
+    handleSelectedLocaleChange: PropTypes.func.isRequired
+}
+
+const SponsorThankYouPage = ({ handleSelectedLocaleChange, i18n }) => {
+    return (
+        <div>
+            <div className="jumbotron jumbotron-fluid">
+            <div className="container">
+                <h1 className="display-4">{`${i18n.t("sponsor_thank_you:title")}`}</h1>
+            </div>
+            </div>
+            <div className="container thank-you-container">
+                <img className="checkmark-image" alt="checkmarx" src="/images/checkmark.png" />
+                <div className="thank-you-text">
+                    <p>{`${i18n.t("sponsor_thank_you:subtitle")}`}</p>
+                    <p>{`${i18n.t("sponsor_thank_you:processed_text")}`}</p>
+                    <p>{`${i18n.t("sponsor_thank_you:impact_text")}`} </p>
+                    <br />
+                    <br />
+                </div>
+            </div>
+            <div className="group-photo-div">
+                <img className="" alt="group-of-students" src="/images/group-student-photo.png" />
+            </div>
+        </div>
+    )
+}
+
+export default SponsorThankYouPage;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "react-router-dom": "^5.2.0",
     "react-router-hash-link": "^1.2.2",
     "sass-loader": "^8.0.2",
+    "serialize-javascript": ">=3.1.0",
     "startbootstrap-agency": "^6.0.1",
     "style-loader": "^1.2.1",
     "url-loader": "^4.1.0",

--- a/frontend/static/scss/basic.scss
+++ b/frontend/static/scss/basic.scss
@@ -24,3 +24,13 @@
     font-size: 0.9rem;
     margin:30px;
 }
+
+.tucklets-button {
+    width: 20%;
+    border-radius: 30px;
+    margin-bottom: 5%;
+}
+
+.tucklets-button:hover {
+	background-color: #3e2763;
+}

--- a/frontend/static/scss/thank-you.scss
+++ b/frontend/static/scss/thank-you.scss
@@ -1,0 +1,25 @@
+.thank-you-text {
+    margin-top:50px;
+    font-size: 1.8rem;
+    font-weight: 300;
+    line-height: 1.2;
+}
+
+.checkmark-image {
+    height:65px;
+    width:65px;
+}
+
+.thank-you-container {
+    text-align:center;
+    margin-top:100px;
+}
+
+.banner {
+    border-bottom: 5px solid #80808014;
+}
+
+.group-photo-div {
+    background-color: #3e2763;
+    text-align:center;
+}

--- a/src/main/java/com/tucklets/app/configs/SpringWebSecurityConfig.java
+++ b/src/main/java/com/tucklets/app/configs/SpringWebSecurityConfig.java
@@ -58,7 +58,7 @@ public class SpringWebSecurityConfig extends WebSecurityConfigurerAdapter {
         httpSecurity
             .authorizeRequests()
             .antMatchers("/", "/css/**", "/js/**", "/images/**", "/**/favicon.ico", "/frontend/dist/**", "/frontend/static/img/**", "/static/img/**").permitAll()
-            .antMatchers("/sponsor-a-child/**", "/sponsor-info/**", "/health", "/test", "/info/**").permitAll()
+            .antMatchers("/sponsor-a-child/**", "/sponsor-info/**", "/health", "/test", "/info/**", "/thank-you/").permitAll()
             .antMatchers("/admin/**").authenticated()
             .anyRequest().authenticated()
             .and()

--- a/src/main/java/com/tucklets/app/containers/SponsorInfoContainer.java
+++ b/src/main/java/com/tucklets/app/containers/SponsorInfoContainer.java
@@ -1,36 +1,28 @@
 package com.tucklets.app.containers;
 
 import com.tucklets.app.containers.admin.ChildDetailsContainer;
-import com.tucklets.app.entities.Child;
-import com.tucklets.app.entities.ChildAdditionalDetail;
+import com.tucklets.app.entities.Donation;
 import com.tucklets.app.entities.Sponsor;
-import com.tucklets.app.entities.enums.DonationDuration;
 
 import java.util.List;
 
 public class SponsorInfoContainer {
 
+    private Donation donation;
     private Sponsor sponsor;
     private List<ChildDetailsContainer> children;
-    private List<DonationDuration> donationDurations;
-    private String[] selectedChildIds;
-    private DonationDuration selectedDonationDuration;
-    private int numChildren;
 
     public SponsorInfoContainer(
+        Donation donation,
         Sponsor sponsor,
-        List<ChildDetailsContainer> children,
-        List<DonationDuration> donationDurations,
-        String[] selectedChildIds,
-        DonationDuration selectedDonationDuration,
-        int numChildren)
-    {
+        List<ChildDetailsContainer> children) {
+        this.donation = donation;
         this.sponsor = sponsor;
         this.children = children;
-        this.donationDurations = donationDurations;
-        this.selectedChildIds = selectedChildIds;
-        this.selectedDonationDuration = selectedDonationDuration;
-        this.numChildren = numChildren;
+    }
+
+    public Donation getDonation() {
+        return donation;
     }
 
     public Sponsor getSponsor() {
@@ -49,35 +41,4 @@ public class SponsorInfoContainer {
         this.children = children;
     }
 
-    public List<DonationDuration> getDonationDurations() {
-        return donationDurations;
-    }
-
-    public void setDonationDurations(List<DonationDuration> donationDurations) {
-        this.donationDurations = donationDurations;
-    }
-
-    public String[] getSelectedChildIds() {
-        return selectedChildIds;
-    }
-
-    public void setSelectedChildIds(String[] selectedChildIds) {
-        this.selectedChildIds = selectedChildIds;
-    }
-
-    public DonationDuration getSelectedDonationDuration() {
-        return selectedDonationDuration;
-    }
-
-    public void setSelectedDonationDuration(DonationDuration selectedDonationDuration) {
-        this.selectedDonationDuration = selectedDonationDuration;
-    }
-
-    public int getNumChildren() {
-        return numChildren;
-    }
-
-    public void setNumChildren(int numChildren) {
-        this.numChildren = numChildren;
-    }
 }

--- a/src/main/java/com/tucklets/app/containers/admin/ChildDetailsContainer.java
+++ b/src/main/java/com/tucklets/app/containers/admin/ChildDetailsContainer.java
@@ -1,5 +1,6 @@
 package com.tucklets.app.containers.admin;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.tucklets.app.entities.Child;
 import com.tucklets.app.entities.ChildAndSponsorAssoc;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,6 +15,13 @@ public class ChildDetailsContainer {
     private ChildAndSponsorAssoc childAndSponsorAssoc;
     private MultipartFile childImageFile;
     private int age;
+
+    public ChildDetailsContainer(){};
+
+    @JsonCreator
+    public ChildDetailsContainer (Integer childId ) {
+        this.child = new Child(Long.valueOf(childId));
+    }
 
     public Child getChild() {
         return child;

--- a/src/main/java/com/tucklets/app/controllers/RedirectController.java
+++ b/src/main/java/com/tucklets/app/controllers/RedirectController.java
@@ -1,0 +1,15 @@
+package com.tucklets.app.controllers;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class RedirectController {
+
+    @GetMapping("/thank-you")
+    public String handleThankYou() {
+        // Redirect back to the main page.
+        return "redirect:/";
+    }
+
+}

--- a/src/main/java/com/tucklets/app/controllers/SponsorInfoController.java
+++ b/src/main/java/com/tucklets/app/controllers/SponsorInfoController.java
@@ -2,26 +2,29 @@ package com.tucklets.app.controllers;
 
 import com.google.gson.Gson;
 import com.tucklets.app.containers.SponsorInfoContainer;
+import com.tucklets.app.containers.admin.ChildDetailsContainer;
 import com.tucklets.app.entities.Child;
+import com.tucklets.app.entities.Donation;
 import com.tucklets.app.entities.Sponsor;
 import com.tucklets.app.entities.enums.DonationDuration;
 import com.tucklets.app.services.AmountService;
 import com.tucklets.app.services.ChildAndSponsorAssociationService;
 import com.tucklets.app.services.ChildService;
+import com.tucklets.app.services.DonationService;
 import com.tucklets.app.services.EmailService;
 import com.tucklets.app.services.ManageChildrenService;
+import com.tucklets.app.services.SponsorAndDonationAssociationService;
 import com.tucklets.app.services.SponsorService;
-import com.tucklets.app.utils.ContainerUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.servlet.ModelAndView;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Controller
@@ -40,6 +43,9 @@ public class SponsorInfoController {
     ChildService childService;
 
     @Autowired
+    DonationService donationService;
+
+    @Autowired
     AmountService amountService;
 
     @Autowired
@@ -47,6 +53,9 @@ public class SponsorInfoController {
 
     @Autowired
     ManageChildrenService manageChildrenService;
+
+    @Autowired
+    SponsorAndDonationAssociationService sponsorAndDonationAssociationService;
 
     @GetMapping(value = "/")
     public String handleSponsorInfoLanding() {
@@ -57,43 +66,57 @@ public class SponsorInfoController {
     @GetMapping(value = "/selections/")
     @ResponseBody
     public String handleChildSelection(@RequestParam(value = "childIds") String[] childrenIds) {
+        // TODO: Validate request params?
+        Long[] childIds = Arrays.stream(childrenIds).map(Long::parseLong).toArray(Long[]::new);
 
-        var selectedChildren = childService.fetchChildByIds(childrenIds);
+        var selectedChildren = childService.fetchChildByIds(childIds);
         var childrenDetailContainers = manageChildrenService.createChildDetailsContainers(selectedChildren);
         var totalDonationAmount = amountService.computeTotalDonationAmount(selectedChildren);
         Sponsor sponsor = new Sponsor();
-        sponsor.setDonationAmount(totalDonationAmount);
+        Donation donation = new Donation(totalDonationAmount);
 
         SponsorInfoContainer sponsorInfoContainer = new SponsorInfoContainer(
-            sponsor,
-            childrenDetailContainers,
-            DonationDuration.getAllDonationDurations(),
-            childrenIds,
-            null,
-            selectedChildren.size());
-        sponsorInfoContainer.setNumChildren(selectedChildren.size());
-
+            donation, sponsor, childrenDetailContainers);
         return GSON.toJson(sponsorInfoContainer);
     }
 
     @PostMapping(value = "/submit")
-    public ModelAndView handleSponsorSubmission(@ModelAttribute SponsorInfoContainer sponsorInfoContainer) {
+    @ResponseBody
+    public String handleSponsorSubmission(@RequestBody SponsorInfoContainer sponsorInfoContainer) {
 
         // TODO: Validate form.
-
         Sponsor sponsor = sponsorInfoContainer.getSponsor();
-        DonationDuration donationDuration = sponsorInfoContainer.getSelectedDonationDuration();
-        List<Child> children = childService.fetchChildByIds(sponsorInfoContainer.getSelectedChildIds());
+        Donation donation = sponsorInfoContainer.getDonation();
+        DonationDuration donationDuration =
+            sponsorInfoContainer.getDonation().getDonationDuration() == null
+                ? DonationDuration.ONE_YEAR
+                : DonationDuration.INDEFINITE;
+
+        // Add donation info.
+        donationService.addDonation(donation);
+        // Add sponsor info.
         sponsorService.addSponsor(sponsor);
 
-        childAndSponsorAssociationService.createAssociation(children, sponsor, donationDuration);
-        childService.setSponsoredChildren(children);
+        sponsorAndDonationAssociationService.createAssociation(sponsor, donation);
+        List<ChildDetailsContainer> childrenContainer = sponsorInfoContainer.getChildren();
 
-        emailService.sendConfirmationEmail(sponsor, children);
 
-        ModelAndView modelAndView = new ModelAndView("thank-you");
-        modelAndView.addObject("localeContainer", ContainerUtils.createLocaleContainer());
+        // SponsorInfoContainer contains selected children, then create children assocs and send email regarding them.
+        if (!childrenContainer.isEmpty()) {
+            Long[] childIds = childrenContainer
+                .stream()
+                .map(childDetailsContainer -> childDetailsContainer.getChild().getChildId())
+                .toArray(Long[]::new);
+            List<Child> children = childService.fetchChildByIds(childIds);
+            childAndSponsorAssociationService.createAssociation(children, sponsor, donationDuration);
+            childService.setSponsoredChildren(children);
+            emailService.sendConfirmationEmail(sponsor, children, donation);
 
-        return modelAndView;
+        }
+        else {
+            // TODO: Generic sponsorship flow; send different email.
+        }
+
+        return "success";
     }
 }

--- a/src/main/java/com/tucklets/app/db/repositories/DonationRepository.java
+++ b/src/main/java/com/tucklets/app/db/repositories/DonationRepository.java
@@ -1,0 +1,11 @@
+package com.tucklets.app.db.repositories;
+
+import com.tucklets.app.entities.Donation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DonationRepository extends CrudRepository<Donation, Long>, JpaRepository<Donation, Long>{
+
+}

--- a/src/main/java/com/tucklets/app/db/repositories/SponsorAndDonationAssociationRepository.java
+++ b/src/main/java/com/tucklets/app/db/repositories/SponsorAndDonationAssociationRepository.java
@@ -1,0 +1,9 @@
+package com.tucklets.app.db.repositories;
+
+import com.tucklets.app.entities.SponsorAndDonationAssoc;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface SponsorAndDonationAssociationRepository extends CrudRepository<SponsorAndDonationAssoc, Long> { }

--- a/src/main/java/com/tucklets/app/entities/Child.java
+++ b/src/main/java/com/tucklets/app/entities/Child.java
@@ -54,6 +54,12 @@ public class Child {
     @Temporal(TemporalType.DATE)
     private Date deletionDate;
 
+    public Child(){};
+
+    public Child(long childId) {
+        this.childId = childId;
+    }
+
     @PrePersist
     void onCreate() {
         Date today = new Date();

--- a/src/main/java/com/tucklets/app/entities/Donation.java
+++ b/src/main/java/com/tucklets/app/entities/Donation.java
@@ -1,0 +1,136 @@
+package com.tucklets.app.entities;
+
+import com.tucklets.app.entities.enums.DonationDuration;
+import com.tucklets.app.entities.enums.PaymentMethod;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.PostLoad;
+import javax.persistence.PrePersist;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.persistence.Transient;
+import java.math.BigDecimal;
+import java.util.Date;
+
+@Entity
+@Table(name = "Donation")
+/**
+ * Table representing a donation. A sponsor can have multiple donations tied to him or her.
+ */
+public class Donation {
+    @Id
+    @SequenceGenerator(name = "donation_generator", initialValue = 1000, allocationSize = 1)
+    @GeneratedValue(generator = "donation_generator")
+    @Column(name = "donation_id", updatable = false, nullable = false)
+    private Long donationId;
+
+    @Column(name = "donation_amount", updatable = false, nullable = false)
+    private BigDecimal donationAmount;
+
+    @Column(name = "donation_duration_value", updatable = false, nullable = false)
+    private int donationDurationValue;
+
+    @Transient
+    private DonationDuration donationDuration;
+
+    @Column(name = "payment_method", updatable = false, nullable = false)
+    @Basic
+    private int paymentMethodValue;
+
+    @Transient
+    private PaymentMethod paymentMethod;
+
+    @Column(name = "creation_date", updatable = false, nullable = false)
+    @Temporal(TemporalType.DATE)
+    private Date creationDate;
+
+    @Column(name = "deletion_date")
+    @Temporal(TemporalType.DATE)
+    private Date deletionDate;
+
+    @PrePersist
+    void onCreate() {
+        if (paymentMethod != null) {
+            this.paymentMethodValue = paymentMethod.getPaymentMethodValue();
+        }
+        if (donationDuration != null) {
+            this.donationDurationValue = donationDuration.getDonationDuration();
+        }
+    }
+
+    @PostLoad
+    void fillTransient() {
+        if (paymentMethodValue > 0) {
+            this.paymentMethod = PaymentMethod.of(paymentMethodValue);
+        }
+        this.donationDuration = DonationDuration.of(donationDurationValue);
+    }
+
+    public Donation() {};
+
+    public Donation(BigDecimal donationAmount) {
+        this.donationAmount = donationAmount;
+    }
+
+    public Long getDonationId() {
+        return donationId;
+    }
+
+    public void setDonationId(Long donationId) {
+        this.donationId = donationId;
+    }
+
+    public BigDecimal getDonationAmount() {
+        return donationAmount;
+    }
+
+    public void setDonationAmount(BigDecimal donationAmount) {
+        this.donationAmount = donationAmount;
+    }
+
+    public int getDonationDurationValue() {
+        return donationDurationValue;
+    }
+
+    public void setDonationDurationValue(int donationDurationValue) {
+        this.donationDurationValue = donationDurationValue;
+    }
+
+    public DonationDuration getDonationDuration() {
+        return donationDuration;
+    }
+
+    public void setDonationDuration(DonationDuration donationDuration) {
+        this.donationDuration = donationDuration;
+    }
+
+    public int getPaymentMethodValue() {
+        return paymentMethodValue;
+    }
+
+    public void setPaymentMethodValue(int paymentMethodValue) {
+        this.paymentMethodValue = paymentMethodValue;
+    }
+
+    public PaymentMethod getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(PaymentMethod paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public Date getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreationDate(Date creationDate) {
+        this.creationDate = creationDate;
+    }
+}

--- a/src/main/java/com/tucklets/app/entities/Sponsor.java
+++ b/src/main/java/com/tucklets/app/entities/Sponsor.java
@@ -1,9 +1,14 @@
 package com.tucklets.app.entities;
 
-import com.tucklets.app.entities.enums.PaymentMethod;
-
-import javax.persistence.*;
-import java.math.BigDecimal;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.PreUpdate;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import java.util.Date;
 
 @Entity
@@ -37,16 +42,6 @@ public class Sponsor {
     @Column(name = "subscribed", nullable = false)
     private boolean subscribed;
 
-    @Column(name = "donation_amount", nullable = false)
-    private BigDecimal donationAmount;
-
-    @Column(name = "payment_method", nullable = false)
-    @Basic
-    private int paymentMethodValue;
-
-    @Transient
-    private PaymentMethod paymentMethod;
-
     @Column(name = "creation_date", nullable = false)
     @Temporal(TemporalType.DATE)
     private Date creationDate;
@@ -58,24 +53,6 @@ public class Sponsor {
     @Column(name = "deletion_date")
     @Temporal(TemporalType.DATE)
     private Date deletionDate;
-
-    @PrePersist
-    void onCreate() {
-        Date today = new Date();
-        this.setCreationDate(today);
-        this.setLastUpdateDate(today);
-
-        if (paymentMethod != null) {
-            this.paymentMethodValue = paymentMethod.getPaymentMethodValue();
-        }
-    }
-
-    @PostLoad
-    void fillTransient() {
-        if (paymentMethodValue > 0) {
-            this.paymentMethod = PaymentMethod.of(paymentMethodValue);
-        }
-    }
 
     @PreUpdate
     void onUpdate() {
@@ -136,22 +113,6 @@ public class Sponsor {
 
     public void setSubscribed(boolean subscribed) {
         this.subscribed = subscribed;
-    }
-
-    public BigDecimal getDonationAmount() {
-        return donationAmount;
-    }
-
-    public void setDonationAmount(BigDecimal donationAmount) {
-        this.donationAmount = donationAmount;
-    }
-
-    public PaymentMethod getPaymentMethod() {
-        return paymentMethod;
-    }
-
-    public void setPaymentMethod(PaymentMethod paymentMethod) {
-        this.paymentMethod = paymentMethod;
     }
 
     public Date getCreationDate() {

--- a/src/main/java/com/tucklets/app/entities/SponsorAndDonationAssoc.java
+++ b/src/main/java/com/tucklets/app/entities/SponsorAndDonationAssoc.java
@@ -1,0 +1,34 @@
+package com.tucklets.app.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "sponsor_donation_assoc")
+/**
+ * Class representing the association of a sponsor to his or her donation. The ids mentioned are the unique ids for each entity.
+ */
+public class SponsorAndDonationAssoc {
+    @Id
+    @SequenceGenerator(name = "sponsor_donation_assoc_generator", initialValue = 3500, allocationSize = 1)
+    @GeneratedValue(generator = "sponsor_donation_assoc_generator")
+    @Column(name = "sponsor_donation_assoc_id", updatable = false, nullable = false)
+    private Long sponsorDonationAssocId;
+
+    @Column(name = "sponsor_id", updatable = false, nullable = false)
+    private long sponsorId;
+
+    @Column(name = "donation_id", updatable = false, nullable = false)
+    private long donationId;
+
+    public SponsorAndDonationAssoc(){};
+
+    public SponsorAndDonationAssoc(long sponsorId, long donationId) {
+        this.sponsorId = sponsorId;
+        this.donationId = donationId;
+    }
+}

--- a/src/main/java/com/tucklets/app/services/ChildAndSponsorAssociationService.java
+++ b/src/main/java/com/tucklets/app/services/ChildAndSponsorAssociationService.java
@@ -1,16 +1,16 @@
 package com.tucklets.app.services;
 
-import com.tucklets.app.db.repositories.ChildAndSponsorAssociationRepository;
-import com.tucklets.app.entities.Child;
-import com.tucklets.app.entities.ChildAndSponsorAssoc;
-import com.tucklets.app.entities.Sponsor;
-import com.tucklets.app.entities.enums.DonationDuration;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+    import com.tucklets.app.db.repositories.ChildAndSponsorAssociationRepository;
+    import com.tucklets.app.entities.Child;
+    import com.tucklets.app.entities.ChildAndSponsorAssoc;
+    import com.tucklets.app.entities.Sponsor;
+    import com.tucklets.app.entities.enums.DonationDuration;
+    import org.springframework.beans.factory.annotation.Autowired;
+    import org.springframework.stereotype.Service;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
+    import java.util.Date;
+    import java.util.List;
+    import java.util.Objects;
 
 @Service
 public class ChildAndSponsorAssociationService {

--- a/src/main/java/com/tucklets/app/services/ChildService.java
+++ b/src/main/java/com/tucklets/app/services/ChildService.java
@@ -59,10 +59,9 @@ public class ChildService {
     /**
      * Fetches all children from a given list of child's id.
      */
-    public List<Child> fetchChildByIds(String[] childrenIds) {
+    public List<Child> fetchChildByIds(Long[] childrenIds) {
         List<Child>children = new ArrayList<>();
-        for (String id : childrenIds) {
-            Long childId = Long.valueOf(id);
+        for (Long childId : childrenIds) {
             Child possibleChild = childRepository.fetchChild(childId).orElse(null);
             if (Objects.nonNull(possibleChild)) {
                 children.add(possibleChild);

--- a/src/main/java/com/tucklets/app/services/DonationService.java
+++ b/src/main/java/com/tucklets/app/services/DonationService.java
@@ -1,0 +1,22 @@
+package com.tucklets.app.services;
+
+import com.tucklets.app.db.repositories.DonationRepository;
+import com.tucklets.app.entities.Donation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@Service
+public class DonationService {
+
+    @Autowired
+    DonationRepository donationRepository;
+
+    public void addDonation(Donation donation) {
+        // Sets creation date to be the current date.
+        donation.setCreationDate(new Date());
+        donationRepository.save(donation);
+    }
+
+}

--- a/src/main/java/com/tucklets/app/services/EmailService.java
+++ b/src/main/java/com/tucklets/app/services/EmailService.java
@@ -1,6 +1,7 @@
 package com.tucklets.app.services;
 
 import com.tucklets.app.entities.Child;
+import com.tucklets.app.entities.Donation;
 import com.tucklets.app.entities.Newsletter;
 import com.tucklets.app.entities.Sponsor;
 import com.tucklets.app.utils.ContainerUtils;
@@ -27,23 +28,24 @@ public class EmailService {
     @Autowired
     SimpleS3Service simpleS3Service;
 
-    public void sendConfirmationEmail(Sponsor sponsor, List<Child> children) {
+    public void sendConfirmationEmail(Sponsor sponsor, List<Child> children, Donation donation) {
         // from recipient is defined in application.properties
         MimeMessagePreparator messagePreparator = message -> {
             MimeMessageHelper helper = new MimeMessageHelper(message, true);
             helper.setTo(sponsor.getEmail());
             helper.setSubject("Tucklets - Thank you sponsoring a child! ");
-            String emailContent = buildThankYouContent(sponsor, children);
+            String emailContent = buildThankYouContent(sponsor, children, donation);
             helper.setText(emailContent, true);
 
         };
         javaMailSender.send(messagePreparator);
     }
 
-    private String buildThankYouContent (Sponsor sponsor, List<Child> children) {
+    private String buildThankYouContent (Sponsor sponsor, List<Child> children, Donation donation) {
         Context context = new Context();
         context.setVariable("children", children);
         context.setVariable("sponsor", sponsor);
+        context.setVariable("donation", donation);
         context.setVariable("localeContainer", ContainerUtils.createLocaleContainer());
 
         return templateEngine.process("emails/confirmation-email", context);

--- a/src/main/java/com/tucklets/app/services/SponsorAndDonationAssociationService.java
+++ b/src/main/java/com/tucklets/app/services/SponsorAndDonationAssociationService.java
@@ -1,0 +1,24 @@
+package com.tucklets.app.services;
+
+import com.tucklets.app.db.repositories.SponsorAndDonationAssociationRepository;
+import com.tucklets.app.entities.Donation;
+import com.tucklets.app.entities.Sponsor;
+import com.tucklets.app.entities.SponsorAndDonationAssoc;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+@Service
+public class SponsorAndDonationAssociationService {
+
+    @Autowired
+    SponsorAndDonationAssociationRepository sponsorAndDonationAssociationRepository;
+
+    public void createAssociation(Sponsor sponsor, Donation donation) {
+        if (Objects.nonNull(donation) && Objects.nonNull(sponsor)) {
+            SponsorAndDonationAssoc sponsorAndDonationAssoc= new SponsorAndDonationAssoc(sponsor.getSponsorId(), donation.getDonationId());
+            sponsorAndDonationAssociationRepository.save(sponsorAndDonationAssoc);
+        }
+    }
+}

--- a/src/main/java/com/tucklets/app/services/SponsorService.java
+++ b/src/main/java/com/tucklets/app/services/SponsorService.java
@@ -34,7 +34,14 @@ public class SponsorService {
         return possibleSponsor.orElse(null);
     }
 
-    public void addSponsor(Sponsor sponsor) { sponsorRepository.save(sponsor); }
+    public void addSponsor(Sponsor sponsor) {
+        Date today = new Date();
+        sponsor.setCreationDate(today);
+        sponsor.setLastUpdateDate(today);
+        // All sponsors will start out as "subscribed".
+        sponsor.setSubscribed(true);
+        sponsorRepository.save(sponsor);
+    }
 
     /**
      * Soft deletes the child with the given id.

--- a/src/main/resources/templates/admin/sponsor-dashboard.html
+++ b/src/main/resources/templates/admin/sponsor-dashboard.html
@@ -29,8 +29,6 @@
         <th scope="col">First Name</th>
         <th scope="col">Last Name</th>
         <th scope="col">Email</th>
-        <th scope="col">Donation Amount</th>
-        <th scope="col">Payment Method</th>
         <th scope="col">Church Name</th>
         <th scope="col">Address</th>
         <th scope="col">Creation Date</th>
@@ -47,8 +45,6 @@
         <td th:text="${sponsor.firstName}"/>
         <td th:text="${sponsor.lastName}"/>
         <td th:text="${sponsor.email}"/>
-        <td th:text="${sponsor.donationAmount}"/>
-        <td th:text="${sponsor.paymentMethod}"/>
         <td th:text="${sponsor.churchName}"/>
         <td th:text="${sponsor.address}"/>
         <td th:text="${sponsor.creationDate}"/>

--- a/src/main/resources/templates/emails/confirmation-email.html
+++ b/src/main/resources/templates/emails/confirmation-email.html
@@ -21,7 +21,7 @@
     <p class="" th:text="|Dear ${sponsor.firstName} ${sponsor.lastName},|"></p>
     <p class="">Thank you for supporting Tuckets, a 501(c)(3) public benefit charitable corporation. </p>
     <p class="">Here is a receipt of your donation: </p>
-    <p class="" th:text="| Amount: $ ${sponsor.donationAmount} |"></p>
+    <p class="" th:text="| Amount: $ ${donation.donationAmount} |"></p>
   </p>
   <div class="" th:each="child : ${children}">
     <p> You have agreed to support the following child: </p>


### PR DESCRIPTION
Added logic to support submission of sponsor info to backend.
Support ability to manually route on the frontend side without use of `<Link />`
Refactored tables; created new Donation table + SponsorAndDonationAssoc table.
TODO: validations, normalizations, frontend validations, etc.