### PR TITLE
Serve compressed files from the server; also added it to Webpack if w…

### DIFF
--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -16,15 +16,14 @@ task webpack(type: NodeTask, dependsOn: 'npmInstall') {
     inputs.dir('jsx')
     outputs.cacheIf { true }
     script = project.file('./node_modules/webpack/bin/webpack.js')
-    args = ['--config', 'webpack.prod.config']
-
+    args = ['--config', 'webpack.prod.config.js']
 }
 
 task webpackDev(type: NodeTask, dependsOn: 'npmInstall') {
     inputs.file('package-lock.json').withPathSensitivity(PathSensitivity.RELATIVE)
     outputs.cacheIf { true }
     script = project.file('./node_modules/webpack/bin/webpack.js')
-    args = ['--config', 'webpack.dev.config']
+    args = ['--config', 'webpack.dev.config.js']
 }
 
 task start(type: NpmTask) {

--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id("com.github.node-gradle.node") version "2.2.3"
+	id("com.github.node-gradle.node") version "2.2.4"
 }
 
 import org.apache.tools.ant.taskdefs.condition.Os
@@ -12,10 +12,19 @@ node {
 }
 
 task webpack(type: NodeTask, dependsOn: 'npmInstall') {
-    inputs.file("package-lock.json").withPathSensitivity(PathSensitivity.RELATIVE)
-    inputs.file("webpack.config.js")
+    inputs.file('package-lock.json').withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.dir('jsx')
     outputs.cacheIf { true }
     script = project.file('./node_modules/webpack/bin/webpack.js')
+    args = ['--config', 'webpack.prod.config']
+
+}
+
+task webpackDev(type: NodeTask, dependsOn: 'npmInstall') {
+    inputs.file('package-lock.json').withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.cacheIf { true }
+    script = project.file('./node_modules/webpack/bin/webpack.js')
+    args = ['--config', 'webpack.dev.config']
 }
 
 task start(type: NpmTask) {
@@ -33,4 +42,4 @@ task stopNodes(type: Exec) {
     }
 }
 
-start.dependsOn('webpack')
+start.dependsOn('webpackDev')

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,8 @@
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/react-fontawesome": "^0.1.9",
     "bootstrap": "^4.5.2",
+    "brotli-webpack-plugin": "^1.1.0",
+    "compression-webpack-plugin": "^6.1.0",
     "css-loader": "^3.5.3",
     "file-loader": "^6.0.0",
     "jquery": "^3.5.1",
@@ -54,6 +56,7 @@
     "startbootstrap-agency": "^6.0.1",
     "style-loader": "^1.2.1",
     "url-loader": "^4.1.0",
+    "webpack-bundle-analyzer": "^4.1.0",
     "webpack-dev-server": "^3.11.0",
     "webpack-hot-middleware": "^2.25.0"
   }

--- a/frontend/webpack.dev.config.js
+++ b/frontend/webpack.dev.config.js
@@ -1,5 +1,8 @@
 const webpack = require('webpack');
 const path = require('path');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+// const BrotliPlugin = require('brotli-webpack-plugin');
+
 module.exports = {
     entry: [
         // entry point
@@ -15,6 +18,19 @@ module.exports = {
 
         new webpack.NamedModulesPlugin(),
         // prints more readable module names in the browser console on HMR updates
+
+        // new BundleAnalyzerPlugin()
+        // new BrotliPlugin({
+        //     asset: '[path].br[query]',
+        //     test: /\.(js|css|html|svg)$/,
+        //     threshold: 10240,
+        //     minRatio: 0.8
+        // })
+        new CompressionPlugin({
+            test: /\.(js|css|html|svg)$/,
+            threshold: 10240,
+            minRatio: 0.8
+        })
     ],
     devServer: {
         contentBase: './dist',

--- a/frontend/webpack.prod.config.js
+++ b/frontend/webpack.prod.config.js
@@ -1,3 +1,6 @@
+const webpack = require('webpack');
+const CompressionPlugin = require('compression-webpack-plugin');
+
 module.exports = {
     entry: [
         './jsx/Main.jsx'
@@ -5,8 +8,15 @@ module.exports = {
     output: {
         filename: 'bundle.js'
     },
-    mode: 'development',
-    devtool: 'source-map',
+    mode: 'production',
+    devtool: '',
+    plugins: [
+        new CompressionPlugin({
+            test: /\.(js|css|html|svg)$/,
+            threshold: 10240,
+            minRatio: 0.8
+        })
+    ],
     module: {
         rules: 
         [

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,3 +43,6 @@ server.ssl.key-store-password=${SSL_KEY_STORE_PASSWORD}
 server.ssl.key-store=classpath:tucklets.p12
 server.ssl.key-store-type=PKCS12
 
+# Allow for compression
+server.compression.enabled: true
+server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css,image/jpeg


### PR DESCRIPTION
Page load can take a while because we were serving the dev build of bundle.js, which is about 3 MB.
Looked into ways for webpack to produce more compressed files (via production build). Also tuned the server to be able to serve compressed content, so bundle.js is now served as a `.gz` (gzipped).

Left the code to compress to `.gz` and `.br` in the webpack.prod.config if we ever want to make use of those compressed builds.
I also renamed webpack.config --> webpack.dev.config.js and webpack.prod.config.js so it's clear which config we are using.