### PR TITLE
UI Tweaks to NavBar

### DIFF
--- a/frontend/jsx/common/LocaleChanger.jsx
+++ b/frontend/jsx/common/LocaleChanger.jsx
@@ -48,7 +48,6 @@ class LocaleChanger extends Component {
         });
         return (
             <div className={`locale-changer ${this.props.additionalClasses}`}>
-                <span className="locale-changer-label" htmlFor="locale-changer">{`${this.props.i18n.t('navigation:language')}`}</span>
                 <select id="locale-changer" value={this.state.selectedLocale} onChange={this.props.handleSelectedLocaleChange}>
                     {localeList}
                 </select>

--- a/frontend/jsx/common/TuckletsNavBar.jsx
+++ b/frontend/jsx/common/TuckletsNavBar.jsx
@@ -73,7 +73,7 @@ class TuckletsNavBar extends Component {
     render() {
         return (
             <div>
-                <Navbar className="tucklets-nav navbar-scroll" expand="lg" fixed="top" expanded={this.state.isNavBarExpanded} onToggle={this.toggleNavBar}>
+                <Navbar className="tucklets-nav navbar-scroll" expand="lg" fixed="top" expanded={this.state.isNavBarExpanded}>
                     <Container>
                     <Navbar.Brand href="/#home">
                         <img

--- a/frontend/jsx/common/TuckletsNavBar.jsx
+++ b/frontend/jsx/common/TuckletsNavBar.jsx
@@ -6,8 +6,6 @@ import Navbar from 'react-bootstrap/Navbar'
 import Container from 'react-bootstrap/Container'
 
 import LocaleChanger from './LocaleChanger';
-import i18n from './i18n';
-
 
 import '../../static/scss/locales.scss';
 import '../../static/scss/info.scss';
@@ -26,19 +24,31 @@ class TuckletsNavBar extends Component {
         super(props);
         this.state = {
             selectedTab: 0,
-            isScrollTop: true }
+            isScrollTop: true,
+            isNavBarExpanded: false
+        }
         // Bind handlers
         this.handleScroll = this.handleScroll.bind(this);
+        this.toggleNavBar = this.toggleNavBar.bind(this);
+        this.collapseNavBar = this.collapseNavBar.bind(this);
     }
 
-    componentDidMount() {
-        window.addEventListener('scroll', this.handleScroll);
-    }
-    
-    componentWillUnmount() {
-        window.removeEventListener('scroll', this.handleScroll);
-    }
+    // 11/11/2020: Commenting out for now, but leaving for reference.
+    // Originally, we wanted to change the navbar's height when the user scrolled past a certain threshold. In order to do this, we had
+    // to break the React paradigm and add event listeners for the 'scroll' event.
 
+    // componentDidMount() {
+    //     window.addEventListener('scroll', this.handleScroll);
+    // }
+
+    // componentWillUnmount() {
+    //     window.removeEventListener('scroll', this.handleScroll);
+    // }
+
+    /**
+     * Scroll handler that determines if the user has scrolled. If scrolling past a certain threshold, update the state.
+     * This was used earlier to determine if we wanted to display the larger Tucklets logo or the condensed one.
+     */
     handleScroll() {
         const isScrollTop = window.scrollY < 100;
         if (isScrollTop !== this.state.isScrollTop) {
@@ -46,27 +56,44 @@ class TuckletsNavBar extends Component {
         }
     }
 
+    /**
+     * Toggle's the state's isNavBarExpanded.
+     */
+    toggleNavBar() {
+        this.setState({ isNavBarExpanded: !this.state.isNavBarExpanded });
+    }
+
+    /**
+     * Collapse the navigation bar.
+     */
+    collapseNavBar() {
+        this.setState({ isNavBarExpanded: false })
+    }
+
     render() {
         return (
             <div>
-                <Navbar className="tucklets-nav navbar-scroll" expand="lg" fixed="top">
+                <Navbar className="tucklets-nav navbar-scroll" expand="lg" fixed="top" expanded={this.state.isNavBarExpanded} onToggle={this.toggleNavBar}>
                     <Container>
                     <Navbar.Brand href="/#home">
                         <img
                             src="../../static/img/tucklets-logo-purple.png"
-                            className={`${this.state.isScrollTop ? "tucklets-logo-regular" : "tucklets-logo-condensed"}`}
+                            // className={`${this.state.isScrollTop ? "tucklets-logo-regular" : "tucklets-logo-condensed"}`}
+                            className="tucklets-logo-condensed"
                             alt="Tucklets Logo"
                         />
                     </Navbar.Brand>
-                    <Navbar.Toggle aria-controls="basic-navbar-nav" />
+                    <button className="navbar-toggler" aria-controls="basic-navbar-nav" onClick={this.toggleNavBar}>
+                        <span className="navbar-toggler-icon" />
+                    </button>
                     <Navbar.Collapse id="basic-navbar-nav">
                         <Nav className="ml-auto nav-links">
-                            <Link className="nav-link js-scroll-trigger" smooth to="/#home">{this.props.i18n.t("navigation:home")}</Link>
-                            <Link className="nav-link js-scroll-trigger" smooth to="/#our-story">{this.props.i18n.t("navigation:our_story")}</Link>
-                            <Link className="nav-link js-scroll-trigger" smooth to="/#about">{this.props.i18n.t("navigation:about")}</Link>
-                            <Link className="nav-link js-scroll-trigger" smooth to="/#newsletters">{this.props.i18n.t("navigation:newsletters")}</Link>
-                            <Link className="nav-link js-scroll-trigger" smooth to="/#donate">{this.props.i18n.t("navigation:donate")}</Link>
-                            <Link className="nav-link js-scroll-trigger" smooth to="/#sponsor-a-child">{this.props.i18n.t("navigation:sponsor_navbar")}</Link>
+                            <Link className="nav-link js-scroll-trigger" smooth to="/#home" onClick={this.collapseNavBar}>{this.props.i18n.t("navigation:home")}</Link>
+                            <Link className="nav-link js-scroll-trigger" smooth to="/#our-story" onClick={this.collapseNavBar}>{this.props.i18n.t("navigation:our_story")}</Link>
+                            <Link className="nav-link js-scroll-trigger" smooth to="/#about" onClick={this.collapseNavBar}>{this.props.i18n.t("navigation:about")}</Link>
+                            <Link className="nav-link js-scroll-trigger" smooth to="/#newsletters" onClick={this.collapseNavBar}>{this.props.i18n.t("navigation:newsletters")}</Link>
+                            <Link className="nav-link js-scroll-trigger" smooth to="/#donate" onClick={this.collapseNavBar}>{this.props.i18n.t("navigation:donate")}</Link>
+                            <Link className="nav-link js-scroll-trigger" smooth to="/#sponsor-a-child" onClick={this.collapseNavBar}>{this.props.i18n.t("navigation:sponsor_navbar")}</Link>
                             <LocaleChanger handleSelectedLocaleChange={this.props.handleSelectedLocaleChange} i18n={this.props.i18n} additionalClasses="nav-link js-scroll-trigger" />
                         </Nav>
                     </Navbar.Collapse>
@@ -80,6 +107,3 @@ class TuckletsNavBar extends Component {
 TuckletsNavBar.propTypes = props;
 
 export default TuckletsNavBar;
-               
-               
-               

--- a/frontend/jsx/common/i18n/navigation/en_us.json
+++ b/frontend/jsx/common/i18n/navigation/en_us.json
@@ -4,6 +4,5 @@
     "newsletters": "NEWSLETTERS",
     "our_story": "OUR STORY",
     "donate": "DONATE",
-    "sponsor_navbar": "SPONSOR",
-    "language": "LANGUAGE"
+    "sponsor_navbar": "SPONSOR"
   }

--- a/frontend/jsx/common/i18n/navigation/zh_tw.json
+++ b/frontend/jsx/common/i18n/navigation/zh_tw.json
@@ -4,6 +4,5 @@
     "newsletters": "時事通訊",
     "our_story": "我們的故事",
     "donate": "捐",
-    "sponsor_navbar": "贊助",
-    "language": "語言"
+    "sponsor_navbar": "贊助"
   }

--- a/frontend/static/scss/basic.scss
+++ b/frontend/static/scss/basic.scss
@@ -13,22 +13,24 @@
         }
     }
     
-    // Overriding bootstrap's .container css class.
-    // Increase the container class's max-width to take up 1740px of the
-    // navbar horizonally for devices with a width of 992px or higher. 
-    @media (min-width: 992px) {
+    // Overriding bootstrap's .container css class (within the .tucklets-nav class).
+    // Increase the container class's max-width to take up 100% of the
+    // navbar horizonally for all device widths.
+
+    @media (min-width: 576px) {
         .container {
-            max-width: 1740px;
+            max-width: 100%;
         }
+    }
+
+    // Overridding bootstrap agency's navbar-scroll.
+    // When scrolling through the page, navbar's background
+    // color will now be white.
+    &.navbar-scroll {
+        background-color: #fff;
     }
 }
 
-// Overridding bootstrap agency's navbar-scroll. 
-// When scrolling through the page, navbar's background 
-// color will now be white.  
-.tucklets-nav.navbar-scroll {
-    background-color: #fff;
-}
 
 
 .tucklets-logo-regular {


### PR DESCRIPTION
- Removed "Language" to save us room on the nav bar. This way, words stay on one line.
- Fixed navbar issue where selecting a link did NOT collapse the navigation menu. This was resolved by adding some internal state to track whether the navbar needed to be expanded or not.
- Add "custom" nav bar toggle (borrowed React Bootstrap's, but just styled it ourselves so we can track state).
- Addressed media query issue that was trying to center Tucklets logo.