### PR TITLE
Added minor responsiveness to sponsor-child page

### DIFF
--- a/frontend/jsx/pages/SponsorChildPage.jsx
+++ b/frontend/jsx/pages/SponsorChildPage.jsx
@@ -56,11 +56,11 @@ class SponsorChildPage extends Component {
                 this.state.children.map((childContainer) => (
                     <label 
                         key={`child-id${childContainer.child.childId}`} 
-                        className={`card child-div ${this.state.childrenSelections[childContainer.child.childId] ? 'selected-overlay' : ''}`} 
+                        className={`card child-div col-12 col-sm-6 col-md-4 ${this.state.childrenSelections[childContainer.child.childId] ? 'selected-overlay' : ''}`} 
                         htmlFor={`checkbox-${childContainer.child.childId}`} 
                         onChange={this.onChildSelection(childContainer.child.childId)}>
                         <div className="sponsor-child-image-container">
-                            <img className="card-img-top" src={childContainer.childImageLocation} alt="Card image cap" />
+                            <img className="card-img-top child-image-box" src={childContainer.childImageLocation} alt="Card image cap" />
                             <div className="card-body">
                                 <h5 className="card-title">{`${childContainer.child.firstName} ${childContainer.child.lastName}`}</h5>
                                 <p className="card-text"><b>{`${this.props.i18n.t("sponsorship:age")}`}</b><span>{`${childContainer.age}`}</span></p>

--- a/frontend/static/scss/sponsor-a-child.scss
+++ b/frontend/static/scss/sponsor-a-child.scss
@@ -60,7 +60,13 @@
 }
 
 .sponsor-child-image-container {
-    height: 500px;
+    height: 400px;
     object-fit: cover;
     overflow: hidden;
+    
+    .child-image-box {
+        height: 200px;
+        background-position: center center;
+        background-size: cover;
+    }
 }


### PR DESCRIPTION
Minor responsiveness to sponsor-child page!
- Implemented what we talked about during brunch on using `col-md-4` and `col-12` to determine the number of child cards to display in a row.
- Updated the card with hardcoded px for now for heights....I think we should maybe update that again so that on small screens, the cards fill the page.