### PR TITLE
Provide support for http2

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,6 +43,10 @@ server.ssl.key-store-password=${SSL_KEY_STORE_PASSWORD}
 server.ssl.key-store=classpath:tucklets.p12
 server.ssl.key-store-type=PKCS12
 
+# Provide support for http2.
+server.http2.enabled=true
+
 # Allow for compression
 server.compression.enabled: true
 server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css,image/jpeg
+


### PR DESCRIPTION
AWS ALB may be trying to look for `http2` version of our resource, which is getting a 302 --> back to login screen. This change supports `http2`, and may resolve the issue.