### PR TITLE
Create S3 buckets for images + newsletters in Terraform

### DIFF
--- a/deployment/fargate-terraform/modules/service/outputs.tf
+++ b/deployment/fargate-terraform/modules/service/outputs.tf
@@ -1,0 +1,3 @@
+output "hosted_zone_id" {
+  value = aws_route53_zone.tucklets_public_zone.zone_id
+}

--- a/deployment/fargate-terraform/s3.tf
+++ b/deployment/fargate-terraform/s3.tf
@@ -1,47 +1,66 @@
 //# S3 configurations for the service.
-//
-//resource "aws_s3_bucket" "tucklets_images" {
-//  bucket            = "tucklets-images"
-//  acl               = "public-read"
-//
-//  cors_rule {
-//    allowed_headers = ["*"]
-//    allowed_methods = ["PUT", "POST"]
-//    allowed_origins = ["https://tucklets.net"]
-//  }
-//
-//  tags = {
-//    Environment     = "Prod"
-//  }
-//}
-//
-//
-//resource "aws_s3_bucket" "tucklets_images_dev" {
-//  bucket            = "tucklets-images-dev"
-//  acl               = "public-read"
-//
-//  cors_rule {
-//    allowed_headers = ["*"]
-//    allowed_methods = ["PUT", "POST"]
-//    allowed_origins = ["https://tucklets.net"]
-//  }
-//
-//  tags = {
-//    Environment     = "Dev"
-//  }
-//}
-//
-//resource "aws_s3_bucket" "tucklets_newsletters_dev" {
-//  bucket            = "tucklets-newsletters-dev"
-//  acl               = "public-read"
-//
-//  cors_rule {
-//    allowed_headers = ["*"]
-//    allowed_methods = ["PUT", "POST"]
-//    allowed_origins = ["https://tucklets.net"]
-//  }
-//
-//  tags = {
-//    Environment     = "Dev"
-//  }
-//}
+
+resource "aws_s3_bucket" "tucklets_images" {
+  bucket            = "tucklets-images"
+  acl               = "public-read"
+
+  hosted_zone_id = module.tucklets_service.hosted_zone_id
+
+  // No need for versioning
+  versioning {
+    enabled         = false
+  }
+
+  tags = {
+    Environment     = "Prod"
+  }
+}
+
+
+resource "aws_s3_bucket" "tucklets_images_dev" {
+  bucket            = "tucklets-images-dev"
+  acl               = "public-read"
+
+  hosted_zone_id = module.tucklets_service.hosted_zone_id
+
+  // No need for versioning
+  versioning {
+    enabled         = false
+  }
+
+  tags = {
+    Environment     = "Dev"
+  }
+}
+
+resource "aws_s3_bucket" "tucklets_newsletters" {
+  bucket            = "tucklets-newsletters"
+  acl               = "public-read"
+
+  hosted_zone_id = module.tucklets_service.hosted_zone_id
+
+  // No need for versioning
+  versioning {
+    enabled         = false
+  }
+
+  tags = {
+    Environment     = "Prod"
+  }
+}
+
+resource "aws_s3_bucket" "tucklets_newsletters_dev" {
+  bucket            = "tucklets-newsletters-dev"
+  acl               = "public-read"
+
+  hosted_zone_id = module.tucklets_service.hosted_zone_id
+
+  // No need for versioning
+  versioning {
+    enabled         = false
+  }
+
+  tags = {
+    Environment     = "Dev"
+  }
+}

--- a/deployment/fargate-terraform/s3.tf
+++ b/deployment/fargate-terraform/s3.tf
@@ -1,14 +1,14 @@
 //# S3 configurations for the service.
 
-resource "aws_s3_bucket" "tucklets_images" {
-  bucket            = "tucklets-images"
+resource "aws_s3_bucket" "tucklets_public" {
+  bucket            = "tucklets-public"
   acl               = "public-read"
 
   hosted_zone_id = module.tucklets_service.hosted_zone_id
 
-  // No need for versioning
+  // Recommended to version buckets.
   versioning {
-    enabled         = false
+    enabled         = true
   }
 
   tags = {
@@ -17,15 +17,15 @@ resource "aws_s3_bucket" "tucklets_images" {
 }
 
 
-resource "aws_s3_bucket" "tucklets_images_dev" {
-  bucket            = "tucklets-images-dev"
+resource "aws_s3_bucket" "tucklets_public_dev" {
+  bucket            = "tucklets-public-dev"
   acl               = "public-read"
 
   hosted_zone_id = module.tucklets_service.hosted_zone_id
 
-  // No need for versioning
+  // Recommended to version buckets.
   versioning {
-    enabled         = false
+    enabled         = true
   }
 
   tags = {
@@ -33,34 +33,43 @@ resource "aws_s3_bucket" "tucklets_images_dev" {
   }
 }
 
-resource "aws_s3_bucket" "tucklets_newsletters" {
-  bucket            = "tucklets-newsletters"
-  acl               = "public-read"
 
-  hosted_zone_id = module.tucklets_service.hosted_zone_id
+resource "aws_s3_bucket_policy" "public_read_prod" {
+  bucket = aws_s3_bucket.tucklets_public.id
 
-  // No need for versioning
-  versioning {
-    enabled         = false
-  }
-
-  tags = {
-    Environment     = "Prod"
-  }
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "prod_tucklets_public_policy",
+  "Statement": [
+    {
+      "Sid":"PublicRead",
+      "Effect":"Allow",
+      "Principal": "*",
+      "Action":["s3:GetObject","s3:GetObjectVersion"],
+      "Resource":["${aws_s3_bucket.tucklets_public.arn}/*"]
+    }
+  ]
+}
+POLICY
 }
 
-resource "aws_s3_bucket" "tucklets_newsletters_dev" {
-  bucket            = "tucklets-newsletters-dev"
-  acl               = "public-read"
+resource "aws_s3_bucket_policy" "public_read_dev" {
+  bucket = aws_s3_bucket.tucklets_public_dev.id
 
-  hosted_zone_id = module.tucklets_service.hosted_zone_id
-
-  // No need for versioning
-  versioning {
-    enabled         = false
-  }
-
-  tags = {
-    Environment     = "Dev"
-  }
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "prod_tucklets_public_policy",
+  "Statement": [
+    {
+      "Sid":"PublicRead",
+      "Effect":"Allow",
+      "Principal": "*",
+      "Action":["s3:GetObject","s3:GetObjectVersion"],
+      "Resource":["${aws_s3_bucket.tucklets_public_dev.arn}/*"]
+    }
+  ]
+}
+POLICY
 }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -3,7 +3,7 @@
 # spring.datasource.url=Stored in AWS Secrets Manager.
 
 # Custom properties
-aws.s3.bucket.name.images=tucklets-images-dev
-aws.s3.bucket.name.newsletters=tucklets-newsletters-dev
-aws.s3.bucket.url.images=https://tucklets-images-dev.s3-us-west-2.amazonaws.com/
-aws.s3.bucket.url.newsletters=https://tucklets-newsletters-dev.s3-us-west-2.amazonaws.com/
+aws.s3.bucket.name.images=tucklets-public-dev/images
+aws.s3.bucket.name.newsletters=tucklets-public-dev/newsletters
+aws.s3.bucket.url.images=https://tucklets-public-dev.s3-us-west-2.amazonaws.com/images/
+aws.s3.bucket.url.newsletters=https://tucklets-public-dev.s3-us-west-2.amazonaws.com/newsletters/

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -50,5 +50,5 @@ server.compression.mime-types=application/json,application/xml,text/html,text/xm
 # Custom properties
 aws.s3.bucket.name.images=tucklets-images
 aws.s3.bucket.name.newsletters=tucklets-newsletters
-aws.s3.bucket.url.images=https://tucklets-images.s3-us-west-1.amazonaws.com/
-aws.s3.bucket.url.newsletters=https://tucklets-newsletters.s3-us-west-1.amazonaws.com/
+aws.s3.bucket.url.images=https://tucklets-images.s3-us-west-2.amazonaws.com/
+aws.s3.bucket.url.newsletters=https://tucklets-newsletters.s3-us-west-2.amazonaws.com/

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,7 +48,7 @@ server.compression.enabled: true
 server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css,image/jpeg
 
 # Custom properties
-aws.s3.bucket.name.images=tucklets-images
-aws.s3.bucket.name.newsletters=tucklets-newsletters
-aws.s3.bucket.url.images=https://tucklets-images.s3-us-west-2.amazonaws.com/
-aws.s3.bucket.url.newsletters=https://tucklets-newsletters.s3-us-west-2.amazonaws.com/
+aws.s3.bucket.name.images=tucklets-public/images
+aws.s3.bucket.name.newsletters=tucklets-public/newsletters
+aws.s3.bucket.url.images=https://tucklets-public.s3-us-west-2.amazonaws.com/images/
+aws.s3.bucket.url.newsletters=https://tucklets-public.s3-us-west-2.amazonaws.com/newsletters/


### PR DESCRIPTION
Create S3 buckets through terraform.
- No module since it's just one file that we are modifying.
- Created -dev buckets as well.
- Use canned ACL (public-read) since we are okay with people accessing the images + buckets (until we put up a CDN).
- Changed schema so we only have 2 S3 buckets: `tucklets-public` and `tucklets-public-dev`. We will have images + newsletters be subdirectories under them.
- Verified that we can upload newsletter + read them (local)