### PR TITLE
Remove fixed height so smaller screen sizes can be responsive with th…

### DIFF
--- a/frontend/static/scss/sponsor-a-child.scss
+++ b/frontend/static/scss/sponsor-a-child.scss
@@ -72,7 +72,6 @@
 }
 
 .sponsor-child-image-container {
-    height: 400px;
     object-fit: cover;
     overflow: hidden;
     


### PR DESCRIPTION
Previously, on smaller screen sizes (iphone), the description for a child got way too close to the border. This is a small fix to keep the spacing even.

Problem: We fixed the height to be 400px, but for smaller resolutions, we actually want the height slightly larger than 400. Since Bootstrap already has some rules for responsiveness and the container is supposed to be responsive, we can remove the fixed height so that it can adapt/respond relative to its parent container's height.