### PR TITLE
Fix submission for sponsor-info

### DIFF
--- a/frontend/jsx/Main.jsx
+++ b/frontend/jsx/Main.jsx
@@ -137,7 +137,7 @@ class Main extends Component {
                 console.log(response);
                 self.setState({ 
                     selectedChildren: response.data.children, 
-                    donation: { donationAmount: response.data.donation.donationAmount, donationDuration: DonationDuration.MONTHLY, paymentMethod: PaymentMethod.PAYPAL},
+                    donation: { donationAmount: response.data.donation.donationAmount, donationDuration: DonationDuration.MONTHLY, paymentMethod: PaymentMethod.PAYPAL },
                     //allowDonationDurationChange: false
                 });
                 // Manually change route after successful response from backend.
@@ -157,7 +157,6 @@ class Main extends Component {
     handleDonationClick(amount, donationDuration, history) {
         this.setState({ 
             donation: { donationAmount: parseInt(amount), donationDuration: donationDuration },
-            //allowDonationDurationChange: true
         });
         // Manually change route after successful validation.
         history.push("/sponsor-info/");

--- a/src/main/java/com/tucklets/app/containers/SponsorInfoContainer.java
+++ b/src/main/java/com/tucklets/app/containers/SponsorInfoContainer.java
@@ -3,14 +3,15 @@ package com.tucklets.app.containers;
 import com.tucklets.app.containers.admin.ChildDetailsContainer;
 import com.tucklets.app.entities.Donation;
 import com.tucklets.app.entities.Sponsor;
+import org.springframework.boot.jackson.JsonComponent;
 
 import java.util.List;
 
 public class SponsorInfoContainer {
 
-    private Donation donation;
-    private Sponsor sponsor;
-    private List<ChildDetailsContainer> children;
+    private final Donation donation;
+    private final Sponsor sponsor;
+    private final List<ChildDetailsContainer> children;
 
     public SponsorInfoContainer(
         Donation donation,
@@ -29,16 +30,9 @@ public class SponsorInfoContainer {
         return sponsor;
     }
 
-    public void setSponsor(Sponsor sponsor) {
-        this.sponsor = sponsor;
-    }
-
     public List<ChildDetailsContainer> getChildren() {
         return children;
     }
 
-    public void setChildren(List<ChildDetailsContainer> children) {
-        this.children = children;
-    }
 
 }

--- a/src/main/java/com/tucklets/app/entities/Donation.java
+++ b/src/main/java/com/tucklets/app/entities/Donation.java
@@ -41,7 +41,7 @@ public class Donation {
 
     @Column(name = "payment_method", updatable = false, nullable = false)
     @Basic
-    private int paymentMethodValue;
+    private String paymentMethodText;
 
     @Transient
     private PaymentMethod paymentMethod;
@@ -57,7 +57,7 @@ public class Donation {
     @PrePersist
     void onCreate() {
         if (paymentMethod != null) {
-            this.paymentMethodValue = paymentMethod.getPaymentMethodValue();
+            this.paymentMethodText = paymentMethod.getPaymentMethodText();
         }
         if (donationDuration != null) {
             this.donationDurationText = donationDuration.getDonationDuration();
@@ -66,9 +66,7 @@ public class Donation {
 
     @PostLoad
     void fillTransient() {
-        if (paymentMethodValue > 0) {
-            this.paymentMethod = PaymentMethod.of(paymentMethodValue);
-        }
+        this.paymentMethod = PaymentMethod.of(paymentMethodText);
         this.donationDuration = DonationDuration.of(donationDurationText);
     }
 
@@ -103,12 +101,12 @@ public class Donation {
         this.donationDuration = donationDuration;
     }
 
-    public int getPaymentMethodValue() {
-        return paymentMethodValue;
+    public String getPaymentMethodText() {
+        return paymentMethodText;
     }
 
-    public void setPaymentMethodValue(int paymentMethodValue) {
-        this.paymentMethodValue = paymentMethodValue;
+    public void setPaymentMethodText(String paymentMethodText) {
+        this.paymentMethodText = paymentMethodText;
     }
 
     public PaymentMethod getPaymentMethod() {

--- a/src/main/java/com/tucklets/app/entities/enums/DonationDuration.java
+++ b/src/main/java/com/tucklets/app/entities/enums/DonationDuration.java
@@ -1,7 +1,6 @@
 package com.tucklets.app.entities.enums;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/tucklets/app/entities/enums/DonationDuration.java
+++ b/src/main/java/com/tucklets/app/entities/enums/DonationDuration.java
@@ -1,6 +1,10 @@
 package com.tucklets.app.entities.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -13,8 +17,8 @@ public enum DonationDuration
 //    SIX_MONTHS(0, "sponsor-info.donationDuration.SIX_MONTHS");
     ONCE("ONCE"),
     MONTHLY("MONTHLY"),
-    ANNUAL("YEARLY"),
-    ANNUAL_RECURRING("YEARLY_RECURRING");
+    YEARLY("YEARLY"),
+    YEARLY_RECURRING("YEARLY_RECURRING");
 
 
     private final String donationDurationText;
@@ -39,5 +43,11 @@ public enum DonationDuration
      */
     public static List<DonationDuration> getAllDonationDurations() {
         return Stream.of(DonationDuration.values()).collect(Collectors.toList());
+    }
+
+
+    @JsonCreator
+    public static DonationDuration forValue(Map<String, String> jsonObject) {
+        return DonationDuration.of(jsonObject.get("value"));
     }
 }

--- a/src/main/java/com/tucklets/app/entities/enums/PaymentMethod.java
+++ b/src/main/java/com/tucklets/app/entities/enums/PaymentMethod.java
@@ -1,26 +1,34 @@
 package com.tucklets.app.entities.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Map;
 import java.util.stream.Stream;
 
 
 public enum PaymentMethod
 {
-    CHECK(0), PAYPAL(1);
+    CHECK("CHECK"), PAYPAL("PAYPAL");
 
-    private int paymentMethodValue;
+    private String paymentMethodText;
 
-    PaymentMethod(int paymentMethodValue) {
-        this.paymentMethodValue = paymentMethodValue;
+    PaymentMethod(String paymentMethodText) {
+        this.paymentMethodText = paymentMethodText;
     }
 
-    public int getPaymentMethodValue() {
-        return paymentMethodValue;
+    public String getPaymentMethodText() {
+        return paymentMethodText;
     }
 
-    public static PaymentMethod of(int paymentMethodValue) {
+    public static PaymentMethod of(String paymentMethodText) {
         return Stream.of(PaymentMethod.values())
-                .filter(p -> p.getPaymentMethodValue() == paymentMethodValue)
+                .filter(p -> p.getPaymentMethodText().equals(paymentMethodText))
                 .findFirst()
                 .orElseThrow(IllegalArgumentException::new);
+    }
+
+    @JsonCreator
+    public static PaymentMethod forValue(Map<String, String> jsonObject) {
+        return PaymentMethod.of(jsonObject.get("value"));
     }
 }

--- a/src/main/java/com/tucklets/app/utils/CalculationUtils.java
+++ b/src/main/java/com/tucklets/app/utils/CalculationUtils.java
@@ -24,7 +24,7 @@ public class CalculationUtils {
     {
         // Going to monthly duration from a yearly one.
         if (desiredDuration == DonationDuration.MONTHLY
-                && (prevDuration == DonationDuration.ANNUAL || prevDuration == DonationDuration.ANNUAL_RECURRING)) {
+                && (prevDuration == DonationDuration.YEARLY || prevDuration == DonationDuration.YEARLY_RECURRING)) {
             return amount.divide(BigDecimal.valueOf(12), RoundingMode.CEILING);
         }
         // Going to a yearly duration from a monthly selection.

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -3,9 +3,9 @@
 # spring.datasource.url=Stored in AWS Secrets Manager.
 
 # Custom properties
-aws.s3.bucket.name.images=tucklets-images-dev
-aws.s3.bucket.name.newsletters=tucklets-newsletters-dev
-aws.s3.bucket.url.images=https://tucklets-images-dev.s3-us-west-2.amazonaws.com/
-aws.s3.bucket.url.newsletters=https://tucklets-newsletters-dev.s3-us-west-2.amazonaws.com/
+aws.s3.bucket.name.images=images
+aws.s3.bucket.name.newsletters=newsletters
+aws.s3.bucket.url.images=https://tucklets-public-dev.s3-us-west-2.amazonaws.com/images/
+aws.s3.bucket.url.newsletters=https://tucklets-public-dev.s3-us-west-2.amazonaws.com/newsletters/
 tucklets.base.url=https://localhost:8443/
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,9 +48,9 @@ server.compression.enabled: true
 server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css,image/jpeg
 
 # Custom properties
-aws.s3.bucket.name.images=tucklets-images
-aws.s3.bucket.name.newsletters=tucklets-newsletters
-aws.s3.bucket.url.images=https://tucklets-images.s3-us-west-1.amazonaws.com/
-aws.s3.bucket.url.newsletters=https://tucklets-newsletters.s3-us-west-1.amazonaws.com/
+aws.s3.bucket.name.images=images
+aws.s3.bucket.name.newsletters=newsletters
+aws.s3.bucket.url.images=https://tucklets-public.s3-us-west-2.amazonaws.com/images/
+aws.s3.bucket.url.newsletters=https://tucklets-public.s3-us-west-2.amazonaws.com/newsletters/
 tucklets.base.url=https://tucklets.net/
 

--- a/src/test/java/com/tucklets/app/CalculationUtilsTest.java
+++ b/src/test/java/com/tucklets/app/CalculationUtilsTest.java
@@ -16,14 +16,14 @@ public class CalculationUtilsTest {
         Assertions.assertEquals(
                 BigDecimal.valueOf(720),
                 CalculationUtils.calculateAmount(
-                        DonationDuration.ANNUAL,
+                        DonationDuration.YEARLY,
                         DonationDuration.MONTHLY,
                         amount));
 
         Assertions.assertEquals(
                 BigDecimal.valueOf(720),
                 CalculationUtils.calculateAmount(
-                        DonationDuration.ANNUAL_RECURRING,
+                        DonationDuration.YEARLY_RECURRING,
                         DonationDuration.MONTHLY,
                         amount));
 
@@ -36,14 +36,14 @@ public class CalculationUtilsTest {
                 BigDecimal.valueOf(60),
                 CalculationUtils.calculateAmount(
                         DonationDuration.MONTHLY,
-                        DonationDuration.ANNUAL,
+                        DonationDuration.YEARLY,
                         amount));
 
         Assertions.assertEquals(
                 BigDecimal.valueOf(60),
                 CalculationUtils.calculateAmount(
                         DonationDuration.MONTHLY,
-                        DonationDuration.ANNUAL_RECURRING,
+                        DonationDuration.YEARLY_RECURRING,
                         amount));
 
     }
@@ -54,15 +54,15 @@ public class CalculationUtilsTest {
         Assertions.assertEquals(
                 BigDecimal.valueOf(720),
                 CalculationUtils.calculateAmount(
-                        DonationDuration.ANNUAL,
-                        DonationDuration.ANNUAL,
+                        DonationDuration.YEARLY_RECURRING,
+                        DonationDuration.YEARLY,
                         amount));
 
         Assertions.assertEquals(
                 BigDecimal.valueOf(720),
                 CalculationUtils.calculateAmount(
-                        DonationDuration.ANNUAL_RECURRING,
-                        DonationDuration.ANNUAL,
+                        DonationDuration.YEARLY_RECURRING,
+                        DonationDuration.YEARLY,
                         amount));
 
     }


### PR DESCRIPTION
We broke submission because of changes to the donation entity (+ paymentMethod enum). These changes help fix the submission flow by adding custom deserializers so SpringBoot can deserialize DonationDuration + PaymentMethod.

Note: May want to do something about the response time for submission.
Note 2: Maybe we should consider flyway (db migration library)?

TODO: Need to update the schema in production to change `paymentMethodValue` into a string.