### PR TITLE
Fix bug that broke donation page to sponsor info page

### DIFF
--- a/frontend/jsx/Main.jsx
+++ b/frontend/jsx/Main.jsx
@@ -168,8 +168,8 @@ class Main extends Component {
         history.push("/sponsor-info/");
     }
 
-        /***
-     * Handler that leads user from donate to sponsor info page.
+    /***
+     * Handles amount changes on sponsor-info page (from donate page).
      */
     donationAmountChangeHandler(event) {
         amount = !event.target.value ? 0 : event.target.value;
@@ -181,8 +181,6 @@ class Main extends Component {
             },
         }));
     }
-
-
 
     /**
      * Handler for donation duration changes.

--- a/frontend/jsx/common/i18n/donate/en_us.json
+++ b/frontend/jsx/common/i18n/donate/en_us.json
@@ -17,6 +17,7 @@
   "form_amount": "Amount",
   "form_payment_method": "Payment Method",
   
+  "donate-once-text": "One-time",
   "donate-monthly-text": "Recurring monthly",
   "donate-yearly-text": "One-time annual",
   "donate-yearly_recurring-text": "Recurring annual",

--- a/frontend/jsx/common/i18n/donate/zh_tw.json
+++ b/frontend/jsx/common/i18n/donate/zh_tw.json
@@ -16,7 +16,8 @@
   "form_amount": "总数",
   "form_duration": "期限",
   "form_payment_method": "Payment Method",
-  
+
+  "donate-once-text": "One-time",
   "donate-monthly-text": "Recurring monthly",
   "donate-yearly-text": "One-time annual",
   "donate-yearly_recurring-text": "Recurring annual",

--- a/frontend/jsx/common/sponsorship/DonationForm.jsx
+++ b/frontend/jsx/common/sponsorship/DonationForm.jsx
@@ -18,13 +18,16 @@ const props = {
     /** Handler for updating donation amount. */
     handleDonationDurationChange: PropTypes.func.isRequired,
     /** Handler for updating the payment method */
-    handlePaymentMethodChange: PropTypes.func.isRequired
+    handlePaymentMethodChange: PropTypes.func.isRequired,
+    /** Boolean that determines whether the amount input field should be read-only. */
+    isAmountFieldDisabled: PropTypes.bool,
+    /** Boolean that indicates whether this form should show limited donation duration options or not. */
+    showLimitedDonationDurationOptions: PropTypes.bool.isRequired
 }
 
 
 
-const DonationForm = ({ i18n, donation, handleDonationDurationChange, handlePaymentMethodChange }) => {
-   
+const DonationForm = ({ i18n, donation, handleDonationDurationChange, handlePaymentMethodChange, isAmountFieldDisabled, showLimitedDonationDurationOptions, handleDonationAmountChange }) => {
     return (
         <div className="donation-info-div">
             <div className="container">
@@ -37,10 +40,12 @@ const DonationForm = ({ i18n, donation, handleDonationDurationChange, handlePaym
                             <Form.Row>
                                 <Form.Group md={3} as={Col} controlId="amount">
                                     <Form.Label>{i18n.t("donate:form_amount")}</Form.Label>
-                                    <Form.Control readOnly 
+                                    <Form.Control 
                                         type="text"
                                         name="donation.amount"
-                                        value={donation.donationAmount}              
+                                        value={donation.donationAmount}
+                                        readOnly={isAmountFieldDisabled} 
+                                        onChange={handleDonationAmountChange}          
                                     />
                                     <Form.Control.Feedback type="invalid">
                                         {i18n.t("sponsor_info:form_error_first_name")}
@@ -59,19 +64,38 @@ const DonationForm = ({ i18n, donation, handleDonationDurationChange, handlePaym
                                     />
                                 </Form.Group>
                             </Form.Row>
-                            <Form.Row>
-                                <Form.Group md={6} as={Col} controlId="duration">
-                                <Form.Label>{i18n.t("donate:form_duration")}</Form.Label>
-                                <br />
-                                <DonationToggle 
-                                    i18n={i18n}
-                                    donation={donation}
-                                    donationField="donationDuration"
-                                    options={[DonationDuration.MONTHLY, DonationDuration.YEARLY, DonationDuration.YEARLY_RECURRING]}
-                                    onClickHandler={handleDonationDurationChange}
-                                />
-                                </Form.Group>
-                            </Form.Row>
+                            {
+                                showLimitedDonationDurationOptions &&
+                                <Form.Row>
+                                    <Form.Group md={6} as={Col} controlId="duration">
+                                    <Form.Label>{i18n.t("donate:form_duration")}</Form.Label>
+                                    <br />
+                                    <DonationToggle 
+                                        i18n={i18n}
+                                        donation={donation}
+                                        donationField="donationDuration"
+                                        options={[DonationDuration.MONTHLY, DonationDuration.ONCE]}
+                                        onClickHandler={handleDonationDurationChange}
+                                    />
+                                    </Form.Group>
+                                </Form.Row>
+                            }
+                            {
+                                !showLimitedDonationDurationOptions &&
+                                <Form.Row>
+                                    <Form.Group md={6} as={Col} controlId="duration">
+                                    <Form.Label>{i18n.t("donate:form_duration")}</Form.Label>
+                                    <br />
+                                    <DonationToggle 
+                                        i18n={i18n}
+                                        donation={donation}
+                                        donationField="donationDuration"
+                                        options={[DonationDuration.MONTHLY, DonationDuration.YEARLY, DonationDuration.YEARLY_RECURRING]}
+                                        onClickHandler={handleDonationDurationChange}
+                                    />
+                                    </Form.Group>
+                                </Form.Row>
+                            }
                         </Col>
                     </Row>
                 </Form>

--- a/frontend/jsx/common/utils/enums.js
+++ b/frontend/jsx/common/utils/enums.js
@@ -9,4 +9,9 @@ export const DonationDuration = {
 export const PaymentMethod = {
     CHECK: {value: "CHECK", i18nKey: "check"},
     PAYPAL: {value: "PAYPAL", i18nKey: "paypal"}
-}
+};
+
+export const DonationOrigin = {
+    DONATE_PAGE: "DonationPage",
+    SPONSORSHIP: "Sponsor"
+};

--- a/frontend/jsx/pages/SponsorInfoPage.jsx
+++ b/frontend/jsx/pages/SponsorInfoPage.jsx
@@ -10,6 +10,7 @@ import SponsorForm from '../common/sponsorship/SponsorForm';
 
 import '../../static/scss/basic.scss';
 import '../../static/scss/sponsor-info.scss';
+import { DonationOrigin } from '../common/utils/enums';
 
 const props = {
     /** i18n object to help with translations.*/
@@ -31,7 +32,11 @@ const props = {
     /** Handler for updating the donation duration. */
     handleDonationDurationChange: PropTypes.func.isRequired,
     /** Handler for updating the donation's payment method. */
-    handlePaymentMethodChange: PropTypes.func.isRequired
+    handlePaymentMethodChange: PropTypes.func.isRequired,
+    /** Enum that indicates which (UI) page the donation originated from. */
+    donationOrigin: PropTypes.string.isRequired,
+    /** Handler for updating the donation amount. */
+    handleDonationAmountChange: PropTypes.func,
 }
 
 class SponsorInfoPage extends Component {
@@ -48,6 +53,10 @@ class SponsorInfoPage extends Component {
 
     render() {
         // TODO: user refreshes the page or somehow gets here without going through the flow, redirect to the main page.
+
+        // If user originated from the donationPage, allow for donatoin amount to be changed + show limited donation duration options.
+        const isAmountFieldDisabled = this.props.donationOrigin === DonationOrigin.DONATE_PAGE ? false : true;
+        const showLimitedOptions = this.props.donationOrigin === DonationOrigin.DONATE_PAGE ? true : false;
         return (
             <div id="sponsor-info" className="sponsor-info">
                 <Jumbotron>
@@ -59,7 +68,10 @@ class SponsorInfoPage extends Component {
                     i18n={this.props.i18n}
                     donation={this.props.donation}
                     handleDonationDurationChange={this.props.handleDonationDurationChange}
-                    handlePaymentMethodChange={this.props.handlePaymentMethodChange}                
+                    handlePaymentMethodChange={this.props.handlePaymentMethodChange}        
+                    isAmountFieldDisabled={isAmountFieldDisabled}   
+                    showLimitedDonationDurationOptions={showLimitedOptions}
+                    handleDonationAmountChange={this.props.handleDonationAmountChange}
                 />
                 <br />
                 <SponsorForm 
@@ -67,6 +79,8 @@ class SponsorInfoPage extends Component {
                     sponsor={this.props.sponsor} 
                     donation={this.props.donation} 
                     sponsorFormClickHandler={this.props.sponsorFormClickHandler(this.props.history)}
+                    handleDonationDurationChange={this.props.handleDonationDurationChange}
+                    handlePaymentMethodChange={this.props.handlePaymentMethodChange}   
                 />
             </div>
         )


### PR DESCRIPTION
Donate Page to Sponsor Info page broke because of changes to donation duration.

To fix this, we needed to display different views for the `DonationForm`. We could have created a new component for this, but we can also reuse the existing one by adding more flags to style the component, which makes the `SponsorInfo` component handle more "state" or logic.

With that in mind, we had to add a new `donationOrigin` to the state, to track the user's flow--did he or she come from the donate page or the sponsorship flow? Each flow will require different `DonationForm` behavior. For example, the backend does not need to be queried in the event of a regular donation--the user just wants to donate x amount--monthly or one-time will be the same amount. So we need to add logic to prevent that request from hitting the backend.