### PR TITLE
Fix s3 bucket url issues + fix delete sponsor flow

### DIFF
--- a/src/main/java/com/tucklets/app/configs/AwsConfig.java
+++ b/src/main/java/com/tucklets/app/configs/AwsConfig.java
@@ -6,9 +6,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class AwsConfig {
 
-    private final String s3ImagesBucketName;
+    private final String s3BucketName;
     private final String s3ImagesBucketUrl;
-    private final String s3NewslettersBucketName;
     private final String s3NewslettersBucketUrl;
 
     /**
@@ -16,27 +15,21 @@ public class AwsConfig {
      * so they can be used regardless of the active profile.
      */
     public AwsConfig(
-            @Value("${aws.s3.bucket.name.images}") String s3ImageBucketName,
+            @Value("${aws.s3.bucket.name}") String s3BucketName,
             @Value("${aws.s3.bucket.url.images}") String s3ImageBucketUrl,
-            @Value("${aws.s3.bucket.name.newsletters}") String s3NewslettersBucketName,
             @Value("${aws.s3.bucket.url.newsletters}") String s3NewslettersBucketUrl)
     {
-        this.s3ImagesBucketName = s3ImageBucketName;
+        this.s3BucketName = s3BucketName;
         this.s3ImagesBucketUrl = s3ImageBucketUrl;
-        this.s3NewslettersBucketName = s3NewslettersBucketName;
         this.s3NewslettersBucketUrl = s3NewslettersBucketUrl;
-    }
-
-    public String getS3ImagesBucketName() {
-        return s3ImagesBucketName;
     }
 
     public String getS3ImagesBucketUrl() {
         return s3ImagesBucketUrl;
     }
 
-    public String getS3NewslettersBucketName() {
-        return s3NewslettersBucketName;
+    public String getS3BucketName() {
+        return s3BucketName;
     }
 
     public String getS3NewslettersBucketUrl() {

--- a/src/main/java/com/tucklets/app/entities/Newsletter.java
+++ b/src/main/java/com/tucklets/app/entities/Newsletter.java
@@ -30,9 +30,10 @@ public class Newsletter {
 
     public Newsletter() {};
 
-    public Newsletter(String filename, Date uploadDate) {
+    public Newsletter(String filename, Date uploadDate, String newsletterLocation) {
         this.filename = filename;
         this.uploadDate = uploadDate;
+        this.newsletterLocation = newsletterLocation;
     }
 
     public Long getNewsletterId() {
@@ -49,10 +50,6 @@ public class Newsletter {
 
     public String getNewsletterLocation() {
         return newsletterLocation;
-    }
-
-    public void setNewsletterLocation(String newsletterLocation) {
-        this.newsletterLocation = newsletterLocation;
     }
 
 }

--- a/src/main/java/com/tucklets/app/services/ChildAdditionalDetailService.java
+++ b/src/main/java/com/tucklets/app/services/ChildAdditionalDetailService.java
@@ -1,7 +1,9 @@
 package com.tucklets.app.services;
 
+import com.tucklets.app.configs.AwsConfig;
 import com.tucklets.app.db.repositories.ChildAdditionalDetailRepository;
 import com.tucklets.app.entities.ChildAdditionalDetail;
+import com.tucklets.app.utils.S3Utils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -13,10 +15,13 @@ public class ChildAdditionalDetailService {
     @Autowired
     ChildAdditionalDetailRepository childAdditionalDetailRepository;
 
+    @Autowired
+    AwsConfig awsConfig;
+
     /**
      * Method that creates a new ChildAdditionalDetail and sets the most recently used image to be archived.
      */
-    public void addImageForChild(String location, long childId) {
+    public void addImageForChild(String filename, long childId) {
 
         // Fetch most recent additional detail object; null if none exists.
         ChildAdditionalDetail previousChildAdditionalDetail =
@@ -29,7 +34,7 @@ public class ChildAdditionalDetailService {
 
         ChildAdditionalDetail childAdditionalDetail = new ChildAdditionalDetail();
         childAdditionalDetail.setChildId(childId);
-        childAdditionalDetail.setImageLocation(location);
+        childAdditionalDetail.setImageLocation(S3Utils.computeS3Key(filename, awsConfig.getS3ImagesBucketUrl()));
         childAdditionalDetailRepository.save(childAdditionalDetail);
     }
 

--- a/src/main/java/com/tucklets/app/services/ManageChildrenService.java
+++ b/src/main/java/com/tucklets/app/services/ManageChildrenService.java
@@ -33,6 +33,8 @@ public class ManageChildrenService {
     @Autowired
     SimpleS3Service simpleS3Service;
 
+    private static final String S3_IMAGES_DIRECTORY = "images/";
+
     /**
      * Handles the updates to the given childDetails object.
      */
@@ -63,9 +65,9 @@ public class ManageChildrenService {
             // Save image location.
             childAdditionalDetailService.addImageForChild(imageKey, child.getChildId());
             simpleS3Service.uploadFile(
-                imageKey,
-                S3Utils.convertMultiPartToFile(childDetails.getChildImageFile()),
-                awsConfig.getS3ImagesBucketName());
+                    S3_IMAGES_DIRECTORY + imageKey,
+                    S3Utils.convertMultiPartToFile(childDetails.getChildImageFile()),
+                    awsConfig.getS3BucketName());
         }
     }
 
@@ -89,10 +91,8 @@ public class ManageChildrenService {
                         childAdditionalDetailService.fetchChildAdditionalDetailById(child.getChildId());
                 String imageLocation = additionalDetails != null
                         ? additionalDetails.getImageLocation()
-                        : Constants.MISSING_PHOTO_URL;
-                childDetailsContainer.setChildImageLocation(
-                        S3Utils.computeS3Key(imageLocation, awsConfig.getS3ImagesBucketUrl())
-                );
+                        : S3Utils.computeS3Key(Constants.MISSING_PHOTO_URL, awsConfig.getS3ImagesBucketUrl());
+                childDetailsContainer.setChildImageLocation(imageLocation);
                 childContainerList.add(childDetailsContainer);
             }
         }
@@ -118,10 +118,9 @@ public class ManageChildrenService {
         ChildAdditionalDetail childAdditionalDetail =
                 childAdditionalDetailService.fetchChildAdditionalDetailById(child.getChildId());
         String imageLocation = childAdditionalDetail == null
-                ? Constants.DEFAULT_IMAGE_LOCATION
+                ? S3Utils.computeS3Key(Constants.MISSING_PHOTO_URL, awsConfig.getS3ImagesBucketUrl())
                 : childAdditionalDetail.getImageLocation();
-        childDetailsContainer.setChildImageLocation(
-            S3Utils.computeS3Key(imageLocation, awsConfig.getS3ImagesBucketUrl()));
+        childDetailsContainer.setChildImageLocation(imageLocation);
         return childDetailsContainer;
     }
 

--- a/src/main/java/com/tucklets/app/utils/NewsletterUtils.java
+++ b/src/main/java/com/tucklets/app/utils/NewsletterUtils.java
@@ -23,18 +23,7 @@ public class NewsletterUtils {
                 newslettersService
                         .fetchAllAvailableNewsletters()
                         .stream()
-                        .map(newsletter -> NewsletterUtils.determineNewsletterLocation(newsletter, awsConfig))
                         .sorted(Comparator.comparing(Newsletter::getUploadDate).reversed())
                         .collect(Collectors.toList()));
-    }
-
-    /**
-     * Given a newsletter, return the same newsletter with the newsletterLocation field set.
-     * This method will determine where the actual location of the newsletter is.
-     */
-    private static Newsletter determineNewsletterLocation(Newsletter newsletter, AwsConfig awsConfig) {
-        newsletter.setNewsletterLocation(
-            S3Utils.computeS3Key(newsletter.getFilename(),awsConfig.getS3NewslettersBucketUrl()));
-        return newsletter;
     }
 }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -3,8 +3,7 @@
 # spring.datasource.url=Stored in AWS Secrets Manager.
 
 # Custom properties
-aws.s3.bucket.name.images=images
-aws.s3.bucket.name.newsletters=newsletters
+aws.s3.bucket.name=tucklets-public-dev
 aws.s3.bucket.url.images=https://tucklets-public-dev.s3-us-west-2.amazonaws.com/images/
 aws.s3.bucket.url.newsletters=https://tucklets-public-dev.s3-us-west-2.amazonaws.com/newsletters/
 tucklets.base.url=https://localhost:8443/

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,8 +48,7 @@ server.compression.enabled: true
 server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css,image/jpeg
 
 # Custom properties
-aws.s3.bucket.name.images=images
-aws.s3.bucket.name.newsletters=newsletters
+aws.s3.bucket.name=tucklets-public
 aws.s3.bucket.url.images=https://tucklets-public.s3-us-west-2.amazonaws.com/images/
 aws.s3.bucket.url.newsletters=https://tucklets-public.s3-us-west-2.amazonaws.com/newsletters/
 tucklets.base.url=https://tucklets.net/

--- a/src/main/resources/static/js/admin/sponsor-dashboard.js
+++ b/src/main/resources/static/js/admin/sponsor-dashboard.js
@@ -14,7 +14,7 @@ function handleDeleteSponsor(sponsorId) {
     console.log(sponsorId);
     let sponsorRow = $('#sponsor-row' + sponsorId);
     $.ajax({
-        url: '/admin/remove-sponsor/',
+        url: '/admin/sponsor-dashboard/remove-sponsor/',
         type: 'DELETE',
         data: {"sponsorId": sponsorId},
         success: function(sponsorInfoResponse) {

--- a/src/main/resources/templates/admin/manage-newsletters.html
+++ b/src/main/resources/templates/admin/manage-newsletters.html
@@ -55,7 +55,7 @@
                     <input class="form-control upload-file-button" type="file" name="file" accept="application/pdf" onchange="handleUploadFile()">
                 </div>
                 <div>
-                    <input class="btn btn-primary upload-button" type="submit" value="Upload" disabled onclick="preventMultipleSubmissions()">
+                    <input class="btn btn-primary upload-button" type="submit" value="Upload" onsubmit="preventMultipleSubmissions()">
                 </div>
             </form>
         </div>


### PR DESCRIPTION
Fixed issues with S3 bucket name/url. 
Root cause: Bucket name was changed earlier--code did not reflect that change.

We now store newsletters with the s3 url as we create them (no reason to wait on it).
Children image locations are only stored if an image file was uploaded.

Delete sponsor was broken because the endpoint was incorrect.