### PR TITLE
Update president email to come from AppCondifg, so different emails =…

### DIFF
--- a/src/main/java/com/tucklets/app/configs/AppConfig.java
+++ b/src/main/java/com/tucklets/app/configs/AppConfig.java
@@ -5,15 +5,24 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class AppConfig {
-    private final String tuckletsBaseUrl;
+
+    private final String baseUrl;
+    private final String presidentEmail;
 
     /* These are the variables stored in application.properties*/
-    public AppConfig(@Value("${tucklets.base.url}") String tuckletsBaseUrl)
+    public AppConfig(
+            @Value("${tucklets.base.url}") String baseUrl,
+            @Value("${tucklets.president.email}") String presidentEmail)
     {
-        this.tuckletsBaseUrl = tuckletsBaseUrl;
+        this.baseUrl = baseUrl;
+        this.presidentEmail = presidentEmail;
     }
 
     public String getTuckletsBaseUrl() {
-        return tuckletsBaseUrl;
+        return baseUrl;
+    }
+
+    public String getPresidentEmail() {
+        return presidentEmail;
     }
 }

--- a/src/main/java/com/tucklets/app/controllers/SponsorInfoController.java
+++ b/src/main/java/com/tucklets/app/controllers/SponsorInfoController.java
@@ -1,6 +1,7 @@
 package com.tucklets.app.controllers;
 
 import com.google.gson.Gson;
+import com.tucklets.app.configs.AppConfig;
 import com.tucklets.app.containers.SponsorInfoContainer;
 import com.tucklets.app.containers.admin.ChildDetailsContainer;
 import com.tucklets.app.entities.Child;
@@ -39,6 +40,9 @@ import java.util.List;
 public class SponsorInfoController {
 
     private static final Gson GSON = new Gson();
+
+    @Autowired
+    AppConfig appConfig;
 
     @Autowired
     SponsorService sponsorService;
@@ -126,13 +130,13 @@ public class SponsorInfoController {
             childAndSponsorAssociationService.createAssociation(children, sponsor, donation.getDonationDuration());
             childService.setSponsoredChildren(children);
             emailService.sendConfirmationEmail(sponsor, children, donation, sponsor.getEmail());
-            emailService.sendConfirmationEmail(sponsor, children, donation, EmailService.PRESIDENT_EMAIL_ADDRESS);
+            emailService.sendConfirmationEmail(sponsor, children, donation, appConfig.getPresidentEmail() );
 
         }
         else {
             // TODO: Generic sponsorship flow; send different email.
             emailService.sendGenericConfirmationEmail(sponsor, donation, sponsor.getEmail());
-            emailService.sendGenericConfirmationEmail(sponsor, donation, EmailService.PRESIDENT_EMAIL_ADDRESS);
+            emailService.sendGenericConfirmationEmail(sponsor, donation, appConfig.getPresidentEmail());
         }
 
         return ResponseEntity.ok(GSON.toJson(sponsorStatus));

--- a/src/main/java/com/tucklets/app/services/EmailService.java
+++ b/src/main/java/com/tucklets/app/services/EmailService.java
@@ -23,9 +23,6 @@ import java.util.List;
 @Service
 public class EmailService {
 
-    // Email address for president of Tucklets (most emails should be forwarded to this email address).
-    public static final String PRESIDENT_EMAIL_ADDRESS = "president@tucklets.net";
-
     @Autowired
     AwsConfig awsConfig;
 
@@ -37,9 +34,6 @@ public class EmailService {
 
     @Autowired
     TemplateEngine templateEngine;
-
-    @Autowired
-    SimpleS3Service simpleS3Service;
 
     /**
      * Generic thank you email for donors.

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -7,4 +7,5 @@ aws.s3.bucket.name=tucklets-public-dev
 aws.s3.bucket.url.images=https://tucklets-public-dev.s3-us-west-2.amazonaws.com/images/
 aws.s3.bucket.url.newsletters=https://tucklets-public-dev.s3-us-west-2.amazonaws.com/newsletters/
 tucklets.base.url=https://localhost:8443/
+tucklets.president.email=tucklets.dev@gmail.com
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -52,4 +52,5 @@ aws.s3.bucket.name=tucklets-public
 aws.s3.bucket.url.images=https://tucklets-public.s3-us-west-2.amazonaws.com/images/
 aws.s3.bucket.url.newsletters=https://tucklets-public.s3-us-west-2.amazonaws.com/newsletters/
 tucklets.base.url=https://tucklets.net/
+tucklets.president.email=president@tucklets.net
 


### PR DESCRIPTION
All submissions from sponsor info page will result in the president of Tucklets getting an email notification. This means a lot of spam as we are testing the submission/payment flows.

Updated our code so the email is read not from a constant but from a config. For production, we can use the president's email. For testing locally, we will use `tucklets.dev@gmail.com`