### PR TITLE
Allow db to store utf-8 characters so we can persist chinese text in …

### DIFF
--- a/src/main/java/com/tucklets/app/utils/TextUtils.java
+++ b/src/main/java/com/tucklets/app/utils/TextUtils.java
@@ -16,8 +16,8 @@ public class TextUtils {
         if (StringUtils.isEmpty(strippedText)) {
             return null;
         }
-        // Escapes the string and removes all escaped characters.
-        String escapedText = StringEscapeUtils.escapeJava(strippedText);
+        // Escapes the string and removes all escaped html characters.
+        String escapedText = StringEscapeUtils.escapeHtml4(strippedText);
         // Remove any suspicious characters.
         return escapedText.replaceAll("[\\\\<>/&;]", "");
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -47,6 +47,13 @@ server.ssl.key-store-type=PKCS12
 server.compression.enabled: true
 server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css,image/jpeg
 
+# Charset of HTTP requests and responses
+server.servlet.encoding.charset=UTF-8
+# Enable http encoding support.
+server.servlet.encoding.enabled=true
+server.servlet.encoding.force=true
+
+
 # Custom properties
 aws.s3.bucket.name=tucklets-public
 aws.s3.bucket.url.images=https://tucklets-public.s3-us-west-2.amazonaws.com/images/


### PR DESCRIPTION
- Chinese text could not be saved in the db because we were escaping Java strings
- Allowing UTF-8 characters in application.properties so we can store Chinese text.
- TODO: Maybe add some tests for TextUtils later.