### PR TITLE
Allow for deletion of donation amount by  user

### DIFF
--- a/frontend/jsx/pages/DonatePage.jsx
+++ b/frontend/jsx/pages/DonatePage.jsx
@@ -30,9 +30,9 @@ class DonatePage extends Component {
 
     /** Handler for donation amount changes. When the amount becomes valid, remove any error styling there may be. */
     handleDonationAmountChange(event) {
-        if (!!event.target.value) {
-            this.setState({ donationAmount: event.target.value, amountHasErrors: false})
-        }
+        const amount = !event.target.value ? "" : event.target.value;
+        this.setState({ donationAmount: amount, amountHasErrors: false})
+        
     }
 
     /** Handler for submitting a donation. */


### PR DESCRIPTION
Bug: When user tries to delete all the donation amount, the first digit remains.

Solution: If `event.target.value` is null/undefined (occurs when you delete everything so the "change" is `""`), then we should replace the amount with "". Previously, we had a conditional check to verify that the new amount was a value...since the empty string is not considered a value, we were not updating the amount properly.