### PR TITLE
Move admin 'tool' options to top of page;e; update existing sponsor o…

### DIFF
--- a/src/main/java/com/tucklets/app/controllers/admin/SponsorDashboardController.java
+++ b/src/main/java/com/tucklets/app/controllers/admin/SponsorDashboardController.java
@@ -1,24 +1,17 @@
 package com.tucklets.app.controllers.admin;
 
 
-import com.tucklets.app.containers.admin.ChildDetailsContainer;
-import com.tucklets.app.entities.Child;
 import com.tucklets.app.entities.Sponsor;
-import com.tucklets.app.entities.enums.DonationDuration;
 import com.tucklets.app.entities.enums.PaymentMethod;
 import com.tucklets.app.services.ManageSponsorService;
 import com.tucklets.app.services.SponsorService;
 import com.tucklets.app.utils.ContainerUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.propertyeditors.CustomDateEditor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
 
 @Controller
@@ -40,8 +33,8 @@ public class SponsorDashboardController {
     }
 
     @DeleteMapping("/remove-sponsor")
-    public String removeChild(@RequestParam("sponsorId") Long sponsorId) {
-        sponsorService.deleteSponsor(sponsorId);
+    public String removeChild(@RequestParam("email") String email) {
+        sponsorService.deleteSponsor(email);
         return "success";
     }
 

--- a/src/main/java/com/tucklets/app/entities/Sponsor.java
+++ b/src/main/java/com/tucklets/app/entities/Sponsor.java
@@ -1,18 +1,14 @@
 package com.tucklets.app.entities;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.PreUpdate;
-import javax.persistence.SequenceGenerator;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
+import javax.persistence.*;
 import java.util.Date;
 
 @Entity
-@Table(name = "Sponsor")
+@Table(
+        name = "Sponsor",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = "email", name = "uniqueEmaileConstraint")}
+)
 /**
  * Class representing the sponsor of a child. Columns should be self-explanatory.
  */

--- a/src/main/java/com/tucklets/app/services/ManageSponsorService.java
+++ b/src/main/java/com/tucklets/app/services/ManageSponsorService.java
@@ -1,22 +1,10 @@
 package com.tucklets.app.services;
 
-import com.tucklets.app.containers.admin.ChildDetailsContainer;
-import com.tucklets.app.db.repositories.ChildRepository;
-import com.tucklets.app.entities.Child;
-import com.tucklets.app.entities.ChildAdditionalDetail;
 import com.tucklets.app.entities.Sponsor;
-import com.tucklets.app.utils.CalculationUtils;
-import com.tucklets.app.utils.Constants;
-import com.tucklets.app.utils.S3Utils;
-import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 
 @Service
@@ -28,12 +16,10 @@ public class ManageSponsorService {
     /**
      * Handles the updates to the given sponsor object.
      */
-    public void updateSponsor(Sponsor sponsor) throws IOException {
-        Sponsor existingSponsor = sponsorService.fetchSponsorById(sponsor.getSponsorId());
+    public void updateSponsor(Sponsor sponsor) {
+        Optional<Sponsor> existingSponsorOptional = sponsorService.fetchSponsorByEmail(sponsor.getEmail());
         // if existingSponsor is not null, then we are updating
-        if (existingSponsor != null) {
-            this.addExistingFieldsToSponsor(sponsor, existingSponsor);
-        }
+        existingSponsorOptional.ifPresent(value -> this.addExistingFieldsToSponsor(sponsor, value));
         //update the sponsor
         sponsorService.addSponsor(sponsor);
     }

--- a/src/main/resources/templates/admin/children-dashboard.html
+++ b/src/main/resources/templates/admin/children-dashboard.html
@@ -20,6 +20,13 @@
         </div>
     </div>
     <div class="children-table">
+
+        <div class="admin-tools-div">
+            <a th:href="@{/admin/children-dashboard/upload}" class="btn btn-primary upload-children-data-button">Upload Children Data</a>
+            <input type="button" class="btn btn-primary" value="Add Child" onclick="handleAddChildClick()" />
+            <input type="button" id="export-children-button" class="btn btn-primary" onclick="exportChildren()" value="Export" />
+        </div>
+
         <h4>Children Information</h4>
         <table class="table table-striped table-bordered children-data-table">
             <thead>
@@ -58,11 +65,7 @@
             </tbody>
         </table>
     </div>
-    <div class="admin-tools-div">
-        <a th:href="@{/admin/children-dashboard/upload}" class="btn btn-primary upload-children-data-button">Upload Children Data</a>
-        <input type="button" class="btn btn-primary" value="Add Child" onclick="handleAddChildClick()" />
-        <input type="button" id="export-children-button" class="btn btn-primary" onclick="exportChildren()" value="Export" />
-    </div>
+
     <div id="modify-child-modal-holder"></div>
 </div>
 </body>

--- a/src/main/resources/templates/admin/manage-newsletters.html
+++ b/src/main/resources/templates/admin/manage-newsletters.html
@@ -23,8 +23,23 @@
 
     <div class="children-table">
         <h4>Newsletters</h4>
+
+        <form class="form-group upload-children-form" th:action="@{/admin/newsletters/upload}" method="post" enctype="multipart/form-data">
+            <p class="import-directions-div">
+                <b>Please upload your newsletter here</b>
+            </p>
+            <div class="upload-area-div">
+                <span>Please upload a file (.pdf). Keep in mind that if you upload a newsletter with the same name, the newsletter will not get uploaded.</span>
+                <input class="form-control upload-file-button" type="file" name="file" accept="application/pdf" onchange="handleUploadFile()">
+            </div>
+            <div>
+                <input class="btn btn-primary upload-button" type="submit" value="Upload" onsubmit="preventMultipleSubmissions()">
+            </div>
+        </form>
+
         <input type="button" class="btn btn-primary upload-button" value="Email latest newsletter" th:onclick="handleEmailNewsletter()" />
         <span class="newsletter hidden-message">Email was sent successfully!</span>
+
         <table class="table table-striped table-bordered children-data-table">
             <thead>
             <tr>
@@ -44,21 +59,6 @@
             </tr>
             </tbody>
         </table>
-
-        <div class="container">
-            <form class="form-group upload-children-form" th:action="@{/admin/newsletters/upload}" method="post" enctype="multipart/form-data">
-                <p class="import-directions-div">
-                    <b>Please upload your newsletter here</b>
-                </p>
-                <div class="upload-area-div">
-                    <span>Please upload a file (.pdf). Keep in mind that if you upload a newsletter with the same name, the newsletter will not get uploaded.</span>
-                    <input class="form-control upload-file-button" type="file" name="file" accept="application/pdf" onchange="handleUploadFile()">
-                </div>
-                <div>
-                    <input class="btn btn-primary upload-button" type="submit" value="Upload" onsubmit="preventMultipleSubmissions()">
-                </div>
-            </form>
-        </div>
     </div>
 </div>
 </body>

--- a/src/main/resources/templates/admin/sponsor-dashboard.html
+++ b/src/main/resources/templates/admin/sponsor-dashboard.html
@@ -20,6 +20,11 @@
   </div>
 
   <div class="children-table">
+
+    <div class="admin-tools-div">
+      <input type="button" class="btn btn-primary" value="Add Sponsor" th:onclick="handleAddSponsorClick()" />
+    </div>
+
     <h4>Sponsor Information</h4>
     <table class="table table-striped table-bordered children-data-table">
       <thead>
@@ -60,9 +65,7 @@
     </table>
 
     <div id="modify-sponsor-modal-holder"></div>
-    <div class="admin-tools-div">
-      <input type="button" class="btn btn-primary" value="Add Sponsor" th:onclick="handleAddSponsorClick()" />
-    </div>
+
   </div>
 </div>
 </body>

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -6,9 +6,6 @@
       <a class="navbar-brand" href="/">
         <img class="d-inline-block align-top tucklets-logo" alt="" th:src="@{/images/tucklets-icon.PNG}"/>
       </a>
-      <select class="supported-languages-dropdown" th:if="${localeContainer.supportedLocales != null}">
-        <option th:each="locale : ${localeContainer.supportedLocales}" th:value="${locale.localeString}" th:text="${locale.localeDisplayName}" th:selected="${locale.localeString} == ${localeContainer.selectedLocaleString}"/>
-      </select>
     </nav>
   </div>
 </div>


### PR DESCRIPTION
Minor bug fixes:
- Admin pages: newsletters, sponsor dashboard, + children dashboard --> Move the admin "options" (like add button) to top of page so admins don't have to scroll all the way down to use those functions.
- Update sponsorship submission flow so that we check against existing sponsors.
- Remove locale changer stuff from admin view.
- Add uniqueness constraint for `email` column in `Sponsor` entity.