### PR TITLE
Spring Sessions for the win!

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,11 @@ dependencies {
 	// Integration with AWS Secrets Manager
 	compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws-secrets-manager-config', version: '2.2.5.RELEASE'
 
+	// Spring Session
+	// https://mvnrepository.com/artifact/org.springframework.session/spring-session-jdbc
+	compile group: 'org.springframework.session', name: 'spring-session-jdbc', version: '2.4.2'
+
+	
 	// Integration Test
 	integrationTestCompile 'org.assertj:assertj-core:3.18.1'
 	integrationTestCompile 'org.springframework.boot:spring-boot-starter-test'

--- a/deployment/fargate-terraform/modules/service/lb.tf
+++ b/deployment/fargate-terraform/modules/service/lb.tf
@@ -26,11 +26,6 @@ resource "aws_lb_target_group" "ecs_https_target_group" {
   vpc_id                = data.aws_vpc.default.id
   target_type           = "ip"
 
-  stickiness {
-    type                = "lb_cookie"
-    enabled             = true
-  }
-
   health_check {
     healthy_threshold   = "5"
     unhealthy_threshold = "3"

--- a/src/main/java/com/tucklets/app/entities/Admin.java
+++ b/src/main/java/com/tucklets/app/entities/Admin.java
@@ -9,11 +9,12 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+import java.io.Serializable;
 import java.util.Date;
 
 @Entity
 @Table(name = "Admin")
-public class Admin {
+public class Admin implements Serializable {
 
     @Id
     @SequenceGenerator(name = "admin_generator", initialValue = 6000, allocationSize = 1)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,6 @@ spring.jpa.show-sql = true
 # schema will be automatically updated accordingly to java entities found in
 # the project
 spring.jpa.hibernate.ddl-auto = update
-spring.datasource.initialization-mode=always
 
 # Allows Hibernate to generate SQL optimized for a particular DBMS
 spring.jpa.database-platform = org.hibernate.dialect.PostgreSQL94Dialect
@@ -32,6 +31,11 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 # File size restrictions:
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
+
+# Spring session
+spring.session.store-type=jdbc
+# TODO: Change this to never when we use Flyway.
+spring.session.jdbc.initialize-schema=always
 
 # SSL; HTTPS
 server.port: 8443


### PR DESCRIPTION
- Sticky sessions do not scale well--if we have more instances, we want to redistribute the traffic of requests across nodes rather than keep them assigned to the node he or she authenticated with.
- To do this, we can manage user sessions ourselves in the DB with Spring Session!
- Implemented it for Hibernate's `ddl-auto: update` for now, will need to turn that off when we move over to Flyway (but copy the current configs for Spring session over to `application-local.properties`
- Tested that admin can log in (new record in table is seen), refreshing keeps us locked in, and logging out removes the user from the tables.