### PR TITLE
Flyway now works with docker composeUp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ dockerCompose {
 
 	environment.put 'ENVIRONMENT', 'docker'
 	environment.put 'LOCAL_AWS_CREDS', "${System.properties['user.home']}/.aws/credentials"
-	environment.put 'FLYWAY_MIGRATIONS_DIR', "${projectDir}/src/main.resources/db/migration"
+	environment.put 'FLYWAY_MIGRATIONS_DIR', "${projectDir}/src/main/resources/db/migration"
 	environment.put 'BUILD_DIR', "${project.buildDir}"
 	environment.put 'DOCKER_ROOT', "${project.buildDir}"
 

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - AWS_PROFILE=tucklets
       - AWS_REGION=us-west-2
     depends_on:
-      - database
+      - flyway
 
   database:
     container_name: postgres-docker
@@ -24,21 +24,21 @@ services:
     command: postgres
     restart: always
     ports:
-      - "5432:5432"
+      - "5433:5432"
     environment:
       - POSTGRES_USER=master
       - POSTGRES_PASSWORD=master
       - POSTGRES_DB=tucklets
 
-#  flyway:
-#    image: "flyway/flyway"
-#    container_name: flyway-migration
-#    environment:
-#      - FLYWYAY_URL=jdbc:postgresql://database:5432/tucklets
-#      - FLYWAY_USER=master
-#      - FLYWAY_PASSWORD=master
-#    command: -locations=filesystem:/flyway/migrations -connectRetries=60 migrate
-#    volumes:
-#      - ${FLYWAY_MIGRATIONS_DIR}:flyway/migrations/
-#    depends_on:
-#      - database
+  flyway:
+    image: "flyway/flyway:7.5.4"
+    container_name: flyway-migration
+    environment:
+      - FLYWAY_URL=jdbc:postgresql://database:5432/tucklets
+      - FLYWAY_USER=master
+      - FLYWAY_PASSWORD=master
+    command: -locations=filesystem:/flyway/migrations -connectRetries=60 migrate
+    volumes:
+      - ${FLYWAY_MIGRATIONS_DIR}:/flyway/migrations/
+    depends_on:
+      - database

--- a/src/main/java/com/tucklets/app/entities/Admin.java
+++ b/src/main/java/com/tucklets/app/entities/Admin.java
@@ -11,16 +11,16 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import java.io.Serializable;
 import java.util.Date;
+import java.util.UUID;
 
 @Entity
 @Table(name = "Admin")
 public class Admin implements Serializable {
 
     @Id
-    @SequenceGenerator(name = "admin_generator", initialValue = 6000, allocationSize = 1)
-    @GeneratedValue(generator = "admin_generator")
+    @GeneratedValue(generator = "UUID")
     @Column(name = "admin_id", updatable = false, nullable = false)
-    private Long adminId;
+    private UUID adminId;
 
     @Column(name = "username", nullable = false)
     private String username;

--- a/src/main/resources/db/migration/V0.3__initial_data.sql
+++ b/src/main/resources/db/migration/V0.3__initial_data.sql
@@ -1,0 +1,34 @@
+-- Recreate admin table so admin_id column stays first
+drop table admin;
+
+CREATE TABLE admin
+(
+    -- changed from bigint to UUID
+    admin_id UUID NOT NULL,
+    creation_date date NOT NULL,
+    deletion_date date,
+    enabled boolean NOT NULL,
+    encrypted_password varchar(255) NOT NULL,
+    last_login_date date NOT NULL,
+    username varchar(255) NOT NULL,
+    PRIMARY KEY (admin_id)
+);
+
+-- Initialize with default admin. Update password before going live
+insert INTO admin(
+	admin_id,
+	creation_date,
+	deletion_date,
+	enabled,
+	encrypted_password,
+	last_login_date,
+	username)
+values (
+	'048d4be1-cdb0-46fd-9577-311ad58ec7f1',
+	'2021-03-13',
+	null,
+	true,
+	'$2a$12$.kxg5AMNoIcK/M6Da.pCeeYJnQos09TBJUYV1/ANBt.iVFfFg4LMS',
+	'2021-03-13',
+	'admin'
+);


### PR DESCRIPTION
1. Added flyway to docker compose so we can now test db migration scripts in a docker locally. 
2. Changed admin_id column type from bigint to uuid
3. Added a script to create Admin user so developers do not need to use info/resetAdmins endpoint anymore
4. Todo: Look into why we have issues with passwords while running application in docker composeUp.  Ie. log in does not work.