### PR TITLE
Integrate BrainTreePaymentContainer into submission flow

### DIFF
--- a/frontend/jsx/Main.jsx
+++ b/frontend/jsx/Main.jsx
@@ -109,7 +109,7 @@ class Main extends Component {
     /**
      * Handler for the sponsor info submission button.
      */
-    handleSponsorshipSubmission(history) {
+    handleSponsorshipSubmission(nonce, history) {
         let self = this;
         return () => {
             let selectedChildIds = [];
@@ -117,7 +117,8 @@ class Main extends Component {
             axios.post('/sponsor-info/submit/', {
                 sponsor: self.state.sponsor,
                 donation: self.state.donation,
-                children: selectedChildIds
+                children: selectedChildIds,
+                brainTreePaymentContainer: nonce
     
             })
             .then(function (response) {

--- a/frontend/jsx/Main.jsx
+++ b/frontend/jsx/Main.jsx
@@ -118,7 +118,9 @@ class Main extends Component {
                 sponsor: self.state.sponsor,
                 donation: self.state.donation,
                 children: selectedChildIds,
-                brainTreePaymentContainer: nonce
+                brainTreePaymentContainer: {
+                    paymentNonce: nonce
+                }
     
             })
             .then(function (response) {

--- a/frontend/jsx/common/sponsorship/BrainTreePaymentContainer.jsx
+++ b/frontend/jsx/common/sponsorship/BrainTreePaymentContainer.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
+import { withRouter } from 'react-router-dom';
 import DropIn from 'braintree-web-drop-in-react';
 import axios from 'axios';
 
@@ -7,7 +8,9 @@ const props = {
     /** i18n object to help with translations.*/
     i18n: PropTypes.object.isRequired,
     /** Amount for payment. */
-    amount: PropTypes.number.isRequired
+    amount: PropTypes.number.isRequired,
+    /** Handler for the submission button */
+    onSubmitHandler: PropTypes.func.isRequired
 }
 
 class BrainTreePaymentContainer extends React.Component {
@@ -33,12 +36,11 @@ class BrainTreePaymentContainer extends React.Component {
   }
 
     async submitPayment() {
-        // Requence paymentNonce value. Await is necessary here since we want to block until we get the response back.
+        // Request paymentNonce value. Await is necessary here since we want to block until we get the response back.
         const { nonce } = await this.instance.requestPaymentMethod();
-        // Post nonce to server.
-        axios.post('/sponsor-info/payment', {
-            paymentNonce: nonce
-        });
+        console.log(nonce);
+        // Post nonce + submit to server.
+        //this.props.onSubmitHandler(nonce, this.props.history)();
 
     }
 
@@ -88,4 +90,4 @@ class BrainTreePaymentContainer extends React.Component {
 
 BrainTreePaymentContainer.props = props;
 
-export default BrainTreePaymentContainer;
+export default withRouter(BrainTreePaymentContainer);

--- a/frontend/jsx/common/sponsorship/BrainTreePaymentContainer.jsx
+++ b/frontend/jsx/common/sponsorship/BrainTreePaymentContainer.jsx
@@ -40,7 +40,7 @@ class BrainTreePaymentContainer extends React.Component {
         const { nonce } = await this.instance.requestPaymentMethod();
         console.log(nonce);
         // Post nonce + submit to server.
-        //this.props.onSubmitHandler(nonce, this.props.history)();
+        this.props.onSubmitHandler(nonce, this.props.history)();
 
     }
 

--- a/frontend/jsx/pages/ConfirmationPage.jsx
+++ b/frontend/jsx/pages/ConfirmationPage.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { PropTypes } from 'prop-types';
 import { withRouter } from 'react-router-dom';
-import { PayPalButton } from 'react-paypal-button-v2';
 
 import ChildImageContainer from '../common/sponsorship/ChildImageContainer';
 import ConfirmationTable from '../common/sponsorship/ConfirmationTable';
@@ -38,7 +37,7 @@ class ConfirmationPage extends Component {
         // Bind handlers here.
         this.renderSelectedChildren = this.renderSelectedChildren.bind(this);
         this.renderPayByCheckView = this.renderPayByCheckView.bind(this);
-        this.renderPayPalButtons = this.renderPayPalButtons.bind(this);
+        this.renderBrainTreePaymentContainer = this.renderBrainTreePaymentContainer.bind(this);
 
     }
 
@@ -79,7 +78,7 @@ class ConfirmationPage extends Component {
                         <p>{this.props.i18n.t("confirm:check_address_line_2")}</p>
                     </div>
                     <div className="confirmation-submission-button">
-                    <div className="btn btn-primary" onClick={this.props.submitButtonHandler(this.props.history)}>{this.props.i18n.t("confirm:check_submit")}</div>
+                    <div className="btn btn-primary" onClick={this.props.submitButtonHandler(null, this.props.history)}>{this.props.i18n.t("confirm:check_submit")}</div>
                 </div>
                 </div>
             </div>
@@ -89,22 +88,15 @@ class ConfirmationPage extends Component {
     /**
      * Renders the PayPal buttons for payment submission.
      */
-    renderPayPalButtons() {
+    renderBrainTreePaymentContainer() {
         return (
-            <PayPalButton
-            amount={this.props.donation.donationAmount}
-            shippingPreference="NO_SHIPPING" // default is "GET_FROM_FILE"
-            onSuccess={() => console.log("Success")}
-            options={{
-                clientId: this.props.payPalClientId
-              }}
-        />
+            <BrainTreePaymentContainer i18n={this.props.i18n} amount={this.props.donation.donationAmount} onSubmitHandler={this.props.submitButtonHandler}/>
         )
     }
 
     render() {
         // TODO: user refreshes the page or somehow gets here without going through the flow, redirect to the main page.
-        let paymentOptions = this.props.donation.paymentMethod === PaymentMethod.CHECK ? this.renderPayByCheckView() :  this.renderPayPalButtons();
+        let paymentOptions = this.props.donation.paymentMethod === PaymentMethod.CHECK ? this.renderPayByCheckView() :  this.renderBrainTreePaymentContainer();
         return (
             <div id="confirmation" className="bg-light">
                 <div className="jumbotron jumbotron-fluid">
@@ -118,7 +110,6 @@ class ConfirmationPage extends Component {
                     <br />
                     {paymentOptions}
                     {/* {this.renderSelectedChildren()} */}
-                    <BrainTreePaymentContainer i18n={this.props.i18n} amount={this.props.donation.donationAmount}/>
                 </div>
             </div>
         )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,6 @@
     "react-cookie": "^4.0.3",
     "react-dom": "^16.13.1",
     "react-i18next": "^11.5.0",
-    "react-paypal-button-v2": "^2.6.2",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
     "yup": "^0.29.3"

--- a/src/main/java/com/tucklets/app/containers/SponsorshipContainer.java
+++ b/src/main/java/com/tucklets/app/containers/SponsorshipContainer.java
@@ -3,23 +3,25 @@ package com.tucklets.app.containers;
 import com.tucklets.app.containers.admin.ChildDetailsContainer;
 import com.tucklets.app.entities.Donation;
 import com.tucklets.app.entities.Sponsor;
-import org.springframework.boot.jackson.JsonComponent;
 
 import java.util.List;
 
-public class SponsorInfoContainer {
+public class SponsorshipContainer {
 
     private final Donation donation;
     private final Sponsor sponsor;
     private final List<ChildDetailsContainer> children;
+    private final BrainTreePaymentContainer brainTreePaymentContainer;
 
-    public SponsorInfoContainer(
+    public SponsorshipContainer(
         Donation donation,
         Sponsor sponsor,
-        List<ChildDetailsContainer> children) {
+        List<ChildDetailsContainer> children,
+        BrainTreePaymentContainer brainTreePaymentContainer) {
         this.donation = donation;
         this.sponsor = sponsor;
         this.children = children;
+        this.brainTreePaymentContainer = brainTreePaymentContainer;
     }
 
     public Donation getDonation() {
@@ -34,5 +36,7 @@ public class SponsorInfoContainer {
         return children;
     }
 
-
+    public BrainTreePaymentContainer getBrainTreePaymentContainer() {
+        return brainTreePaymentContainer;
+    }
 }

--- a/src/main/java/com/tucklets/app/controllers/SponsorInfoController.java
+++ b/src/main/java/com/tucklets/app/controllers/SponsorInfoController.java
@@ -4,7 +4,7 @@ import com.braintreegateway.*;
 import com.google.gson.Gson;
 import com.tucklets.app.configs.AppConfig;
 import com.tucklets.app.containers.BrainTreePaymentContainer;
-import com.tucklets.app.containers.SponsorInfoContainer;
+import com.tucklets.app.containers.SponsorshipContainer;
 import com.tucklets.app.containers.admin.ChildDetailsContainer;
 import com.tucklets.app.entities.Child;
 import com.tucklets.app.entities.Donation;
@@ -85,14 +85,14 @@ public class SponsorInfoController {
         // For now, force monthly payment frequency.
         Donation donation = new Donation(totalDonationAmount, DonationDuration.MONTHLY);
 
-        SponsorInfoContainer sponsorInfoContainer = new SponsorInfoContainer(
-            donation, sponsor, childrenDetailContainers);
+        SponsorshipContainer sponsorInfoContainer = new SponsorshipContainer(
+            donation, sponsor, childrenDetailContainers, new BrainTreePaymentContainer());
         return GSON.toJson(sponsorInfoContainer);
     }
 
     @PostMapping(value = "/submit")
     @ResponseBody
-    public ResponseEntity<String> handleSponsorSubmission(@RequestBody SponsorInfoContainer sponsorInfoContainer) {
+    public ResponseEntity<String> handleSponsorSubmission(@RequestBody SponsorshipContainer sponsorInfoContainer) {
 
         Sponsor sponsor = sponsorInfoContainer.getSponsor();
         Donation donation = sponsorInfoContainer.getDonation();


### PR DESCRIPTION
- Hook up previous BrainTree payment logic into the actual submission.
- Submission method now takes in a `nonce` and we provide the nonce when invoking the submission method.
- Flow: If you pay by check, nonce = null and you call submission directly. If we render BrainTreePaymentContainer, we block until we get nonce and then invoke submission method with nonce. We use the `()` at the end to execute the method (method that returns a method).
- Removed paypal buttons library from our project.
- Renamed `SponsorInfoContainer` --> `SponsorshipContainer`