### PR TITLE
Update braintree logic with subscription code

### DIFF
--- a/src/main/java/com/tucklets/app/entities/enums/DonationDuration.java
+++ b/src/main/java/com/tucklets/app/entities/enums/DonationDuration.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -14,20 +15,26 @@ public enum DonationDuration
 //    THREE_YEAR(2, "sponsor-info.donationDuration.THREE_YEARS"),
 //    INDEFINITE(3, "sponsor-info.donationDuration.INDEFINITE"),
 //    SIX_MONTHS(0, "sponsor-info.donationDuration.SIX_MONTHS");
-    ONCE("ONCE"),
-    MONTHLY("MONTHLY"),
-    YEARLY("YEARLY"),
-    YEARLY_RECURRING("YEARLY_RECURRING");
+    ONCE("ONCE", "no-plan"),
+    MONTHLY("MONTHLY", "MonthlySponsorship"),
+    YEARLY("YEARLY", "YearlySponsorship"),
+    YEARLY_RECURRING("YEARLY_RECURRING", "no-plan-recurring-yearly");
 
 
     private final String donationDurationText;
+    private final String brainTreePlanId;
 
-    DonationDuration(String donationDurationText) {
+    DonationDuration(String donationDurationText, String brainTreePlanId) {
         this.donationDurationText = donationDurationText;
+        this.brainTreePlanId = brainTreePlanId;
     }
 
     public String getDonationDuration() {
         return donationDurationText;
+    }
+
+    public String getBrainTreePlanId() {
+        return brainTreePlanId;
     }
 
     public static DonationDuration of(String donationDurationText) {
@@ -43,6 +50,13 @@ public enum DonationDuration
     public static List<DonationDuration> getAllDonationDurations() {
         return Stream.of(DonationDuration.values()).collect(Collectors.toList());
     }
+
+
+    /**
+     * Set of donation durations that are not recurring.
+     */
+    public static Set<DonationDuration> NON_RECURRING_DONATION_DURATIONS =
+            Set.of(DonationDuration.ONCE, DonationDuration.YEARLY);
 
 
     @JsonCreator


### PR DESCRIPTION
TODO:
- Create association table for sponsor --> customer_id + subscription_id on BrainTree side. This info will allow us to map customers and sponsors across the two systems (cancellations are easier this way).
- Error handling for customers + subscriptions.

- Added new plans to Sandbox + set up flow for subscriptions. Subscriptions will always override the plan's amount with the amount provided by the backend.
- Created a set to house all non-recurring `DonationDuration`s.
- Added `brainTreePlanId` to donationDuration.