### PR TITLE
Use manually created SMTP user for sending emails

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,15 +19,18 @@ spring.jpa.database-platform = org.hibernate.dialect.PostgreSQL94Dialect
 spring.messages.basename=i18n.messages
 
 # email
-spring.mail.host=smtp.gmail.com
-spring.mail.port=587
+spring.mail.host=email-smtp.us-west-2.amazonaws.com
+spring.mail.port=465
 # spring.mail.username/password stored in AWS Secrets Manager
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.connectiontimeout=5000
 spring.mail.properties.mail.smtp.timeout=5000
 spring.mail.properties.mail.smtp.writetimeout=5000
-# TLS , port 587
 spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.protocol=smtps
+spring.mail.smtps.auth=true
+spring.mail.smtp.ssl.enable=true
+
 
 # File size restrictions:
 spring.servlet.multipart.max-file-size=10MB


### PR DESCRIPTION
We should be able to send emails with SES now...

Manual steps:
- Navigated to AWS console for SES.
- Created new IAM user + SMTP credentials
- Loaded those creds into Secrets Manager
- Updated the application.properties to use the smtp configuration.