### PR TITLE
Resolve confirmation table ui issues; replace PAYPAL payment method w…

### DIFF
--- a/frontend/jsx/Main.jsx
+++ b/frontend/jsx/Main.jsx
@@ -58,7 +58,7 @@ class Main extends Component {
             donation: {
                 donationAmount: 0, 
                 donationDuration: DonationDuration.MONTHLY,
-                paymentMethod: PaymentMethod.PAYPAL }, // default payment method is Paypal. Other options include Check
+                paymentMethod: PaymentMethod.OTHER }, // default payment method is OTHER(credit card/PayPal). Other options include 'check'.
             payPalClientId: "",
             donationOrigin: DonationOrigin.DONATE_PAGE
         };

--- a/frontend/jsx/common/i18n/donate/en_us.json
+++ b/frontend/jsx/common/i18n/donate/en_us.json
@@ -22,7 +22,7 @@
   "donate-yearly-text": "One-time annual",
   "donate-yearly_recurring-text": "Recurring annual",
   "donate-check-text": "Check",
-  "donate-paypal-text": "PayPal",
+  "donate-other-text": "Other",
   "donate-submit-text": "Submit"
 
 }

--- a/frontend/jsx/common/i18n/donate/zh_tw.json
+++ b/frontend/jsx/common/i18n/donate/zh_tw.json
@@ -22,7 +22,7 @@
   "donate-yearly-text": "One-time annual",
   "donate-yearly_recurring-text": "Recurring annual",
   "donate-check-text": "Check",
-  "donate-paypal-text": "PayPal",
+  "donate-other-text": "Other",
   "donate-submit-text": "Submit"
 
 }

--- a/frontend/jsx/common/sponsorship/ConfirmationTable.jsx
+++ b/frontend/jsx/common/sponsorship/ConfirmationTable.jsx
@@ -6,6 +6,13 @@ import '../../../static/scss/confirmation';
  * Component used to generate the confirmation div/table.
  */
 const ConfirmationTable = ({ i18n, sponsor, donation }) => {
+    // Create our number formatter.
+    console.log(i18n.language);
+    let currencyFormatter = new Intl.NumberFormat(i18n.language, {
+        style: 'currency',
+        currency: 'USD',
+    });
+    console.log(sponsor.address)
     return (
         <div className="confirmation-summary">
             <h4 className="confirmation-header">{i18n.t("confirm:personal")}</h4>
@@ -35,9 +42,9 @@ const ConfirmationTable = ({ i18n, sponsor, donation }) => {
                                 <span>{sponsor.email}</span>
                             </td>
                             <td>
-                                { sponsor.address.streetAddress == "" && <span>{i18n.t("confirm:not_provided")}</span>}
+                                { sponsor.address.streetAddress1 === "" && <span>{i18n.t("confirm:not_provided")}</span>}
 
-                                { sponsor.address.streetAddress != "" && 
+                                { sponsor.address.streetAddress1 !== "" && 
                                     <div><span>{sponsor.address.streetAddress} </span><br />
                                     <span>{sponsor.address.city}, {sponsor.address.state} {sponsor.address.zip}</span> <br />
                                     <span>{sponsor.address.country}</span></div> }
@@ -64,7 +71,7 @@ const ConfirmationTable = ({ i18n, sponsor, donation }) => {
                             <span>{i18n.t(`confirm:${donation.donationDuration.value.toLowerCase()}`)}</span>
                             </td>
                             <td>
-                                <span>{donation.donationAmount}</span>
+                                <span>{currencyFormatter.format(donation.donationAmount)}</span>
                             </td>
                         </tr>
                     </tbody>

--- a/frontend/jsx/common/sponsorship/ConfirmationTable.jsx
+++ b/frontend/jsx/common/sponsorship/ConfirmationTable.jsx
@@ -7,12 +7,10 @@ import '../../../static/scss/confirmation';
  */
 const ConfirmationTable = ({ i18n, sponsor, donation }) => {
     // Create our number formatter.
-    console.log(i18n.language);
     let currencyFormatter = new Intl.NumberFormat(i18n.language, {
         style: 'currency',
         currency: 'USD',
     });
-    console.log(sponsor.address)
     return (
         <div className="confirmation-summary">
             <h4 className="confirmation-header">{i18n.t("confirm:personal")}</h4>

--- a/frontend/jsx/common/sponsorship/DonationForm.jsx
+++ b/frontend/jsx/common/sponsorship/DonationForm.jsx
@@ -59,7 +59,7 @@ const DonationForm = ({ i18n, donation, handleDonationDurationChange, handlePaym
                                         i18n={i18n}
                                         donation={donation}
                                         donationField="paymentMethod"
-                                        options={[PaymentMethod.PAYPAL, PaymentMethod.CHECK]}
+                                        options={[PaymentMethod.OTHER, PaymentMethod.CHECK]}
                                         onClickHandler={handlePaymentMethodChange}
                                     />
                                 </Form.Group>

--- a/frontend/jsx/common/utils/enums.js
+++ b/frontend/jsx/common/utils/enums.js
@@ -8,7 +8,7 @@ export const DonationDuration = {
 
 export const PaymentMethod = {
     CHECK: {value: "CHECK", i18nKey: "check"},
-    PAYPAL: {value: "PAYPAL", i18nKey: "paypal"}
+    OTHER: {value: "OTHER", i18nKey: "other"}
 };
 
 export const DonationOrigin = {

--- a/src/main/java/com/tucklets/app/entities/enums/PaymentMethod.java
+++ b/src/main/java/com/tucklets/app/entities/enums/PaymentMethod.java
@@ -8,7 +8,7 @@ import java.util.stream.Stream;
 
 public enum PaymentMethod
 {
-    CHECK("CHECK"), PAYPAL("PAYPAL");
+    CHECK("CHECK"), OTHER("OTHER");
 
     private String paymentMethodText;
 

--- a/src/test/java/com/tucklets/app/validations/DonationValidatorTest.java
+++ b/src/test/java/com/tucklets/app/validations/DonationValidatorTest.java
@@ -35,7 +35,7 @@ public class DonationValidatorTest {
         Donation validDonation = new Donation();
         validDonation.setDonationAmount(BigDecimal.TEN);
         validDonation.setDonationDuration(DonationDuration.MONTHLY);
-        validDonation.setPaymentMethod(PaymentMethod.PAYPAL);
+        validDonation.setPaymentMethod(PaymentMethod.OTHER);
 
         Assert.isTrue(
                 DonationValidator.validateDonation(validDonation),


### PR DESCRIPTION
UI Changes:
- Toggle now specifies CHECK vs OTHER rather than PAYPAL.
- Updated text, "Not provided" if `streetAddress1` is null
- Add formatter for currency in confirmation table
- Update PaymentMethod in backend